### PR TITLE
Refactor desktop recorder into layered architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.0] - 2024-05-26
+### Changed
+- Reestructura completa hacia una arquitectura estilo MVC con controladores, servicios, DAOs, DTOs y vistas independientes.
+- Extracción de la lógica de historiales y lanzamiento de Chrome a servicios reutilizables.
+
+### Added
+- Punto de entrada `main.py` y documentación de arquitectura resaltando que se trata de una aplicación de escritorio.
+
 ## [0.1.2] - 2024-05-26
 ### Added
 - Directriz en `AGENTS.md` para organizar las vistas en módulos según la acción o caso de uso.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Package for the desktop recorder application."""

--- a/app/controllers/__init__.py
+++ b/app/controllers/__init__.py
@@ -1,0 +1,1 @@
+"""Package for the desktop recorder application."""

--- a/app/controllers/main_controller.py
+++ b/app/controllers/main_controller.py
@@ -1,0 +1,44 @@
+"""Controller coordinating the desktop view with domain services."""
+
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from app.daos.history_dao import FileHistoryDAO
+from app.services.browser_service import BrowserService
+from app.services.history_service import HistoryService
+from app.services.naming_service import NamingService
+
+
+class MainController:
+    """Expose high-level actions required by the Tkinter views."""
+
+    DEFAULT_URL = "http://localhost:8080/ELLiS/login"
+    CONF_DEFAULT = "https://sistemaspremium.atlassian.net/wiki/spaces/"
+
+    def __init__(self) -> None:
+        """Bootstrap all services used by the desktop application."""
+        self._history_services: Dict[Path, HistoryService] = {}
+        self._browser_service = BrowserService()
+        self._naming_service = NamingService()
+
+    def _get_history_service(self, file_path: Path) -> HistoryService:
+        """Lazy-load the history service associated to a specific file."""
+        if file_path not in self._history_services:
+            self._history_services[file_path] = HistoryService(FileHistoryDAO(file_path))
+        return self._history_services[file_path]
+
+    def load_history(self, file_path: Path, default_value: str) -> List[str]:
+        """Return the stored history for a file path."""
+        return self._get_history_service(file_path).load_history(default_value)
+
+    def register_history_value(self, file_path: Path, value: str) -> None:
+        """Store a new value in the history file."""
+        self._get_history_service(file_path).register_value(value)
+
+    def open_chrome_with_profile(self, url: str, profile_dir: str = "Default") -> Tuple[bool, str]:
+        """Delegate the browser opening logic to the service layer."""
+        return self._browser_service.open_with_profile(url, profile_dir)
+
+    def slugify_for_windows(self, name: str) -> str:
+        """Expose the naming helper for view usage."""
+        return self._naming_service.slugify_for_windows(name)

--- a/app/daos/__init__.py
+++ b/app/daos/__init__.py
@@ -1,0 +1,1 @@
+"""Package for the desktop recorder application."""

--- a/app/daos/history_dao.py
+++ b/app/daos/history_dao.py
@@ -1,0 +1,46 @@
+"""Data access layer for reading and writing history information."""
+
+from pathlib import Path
+from typing import List
+import json
+
+from app.dtos.history_entry import HistoryEntry
+
+
+class FileHistoryDAO:
+    """Provide CRUD-like helpers for list-based history files."""
+
+    def __init__(self, file_path: Path, capacity: int = 15) -> None:
+        """Store the location of the history file and its max capacity."""
+        self.file_path = file_path
+        self.capacity = capacity
+
+    def load(self, default_value: str) -> List[HistoryEntry]:
+        """Load the history from disk returning DTO instances."""
+        if not self.file_path.exists():
+            return [HistoryEntry(default_value)]
+        try:
+            raw_data = json.loads(self.file_path.read_text(encoding="utf-8"))
+        except Exception:
+            return [HistoryEntry(default_value)]
+        if not isinstance(raw_data, list) or not raw_data:
+            return [HistoryEntry(default_value)]
+        return [HistoryEntry(str(item)) for item in raw_data]
+
+    def save(self, value: str) -> None:
+        """Insert a new value on top of the history file."""
+        clean_value = value.strip()
+        if not clean_value:
+            return
+        history = [entry.value for entry in self.load(clean_value)]
+        if any(item.lower() == clean_value.lower() for item in history):
+            return
+        updated = [clean_value] + [item for item in history if item.lower() != clean_value.lower()]
+        updated = updated[: self.capacity]
+        try:
+            self.file_path.write_text(
+                json.dumps(updated, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except Exception:
+            return

--- a/app/dtos/__init__.py
+++ b/app/dtos/__init__.py
@@ -1,0 +1,1 @@
+"""Package for the desktop recorder application."""

--- a/app/dtos/history_entry.py
+++ b/app/dtos/history_entry.py
@@ -1,0 +1,10 @@
+"""Data Transfer Objects used across the desktop recorder application."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class HistoryEntry:
+    """Represent a single string value stored in a history file."""
+
+    value: str

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,1 @@
+"""Package for the desktop recorder application."""

--- a/app/services/browser_service.py
+++ b/app/services/browser_service.py
@@ -1,0 +1,34 @@
+"""Utilities for interacting with the local Chrome installation."""
+
+from pathlib import Path
+from typing import Optional, Tuple
+import shutil
+import subprocess
+
+
+class BrowserService:
+    """Handle launching Chrome with predefined profiles."""
+
+    def find_chrome(self) -> Optional[Path]:
+        """Locate the Chrome executable in the current system."""
+        candidates = [
+            Path(r"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"),
+            Path(r"C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"),
+            Path(shutil.which("chrome") or ""),
+        ]
+        for candidate in candidates:
+            if candidate and candidate.exists():
+                return candidate
+        return None
+
+    def open_with_profile(self, url: str, profile_dir: str = "Default") -> Tuple[bool, str]:
+        """Start Chrome with a specific profile returning success information."""
+        executable = self.find_chrome()
+        if not executable:
+            return False, "No se encontró chrome.exe"
+        args = [str(executable), f"--profile-directory={profile_dir}", url]
+        try:
+            subprocess.Popen(args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except Exception as error:  # pragma: no cover - relies on OS interaction
+            return False, str(error)
+        return True, ""

--- a/app/services/history_service.py
+++ b/app/services/history_service.py
@@ -1,0 +1,19 @@
+"""Business logic to manage history entries for the desktop UI."""
+
+from typing import List
+
+from app.daos.history_dao import FileHistoryDAO
+class HistoryService:
+    """Expose high-level operations for URL and Confluence histories."""
+
+    def __init__(self, dao: FileHistoryDAO) -> None:
+        """Create the service with its associated DAO instance."""
+        self.dao = dao
+
+    def load_history(self, default_value: str) -> List[str]:
+        """Return the history values as plain strings for the view layer."""
+        return [entry.value for entry in self.dao.load(default_value)]
+
+    def register_value(self, value: str) -> None:
+        """Persist a new history entry when a view triggers it."""
+        self.dao.save(value)

--- a/app/services/naming_service.py
+++ b/app/services/naming_service.py
@@ -1,0 +1,40 @@
+"""Helpers to generate filesystem friendly names."""
+
+import re
+
+
+class NamingService:
+    """Apply transformations to keep filenames compatible with Windows."""
+
+    def slugify_for_windows(self, name: str) -> str:
+        """Return a sanitized slug valid for Windows file systems."""
+        clean_name = (name or "").strip()
+        clean_name = re.sub(r'[<>:"/\\|?*\\x00-\\x1F]', "", clean_name)
+        clean_name = re.sub(r"\\s+", "_", clean_name)
+        reserved = {
+            "CON",
+            "PRN",
+            "AUX",
+            "NUL",
+            "COM1",
+            "COM2",
+            "COM3",
+            "COM4",
+            "COM5",
+            "COM6",
+            "COM7",
+            "COM8",
+            "COM9",
+            "LPT1",
+            "LPT2",
+            "LPT3",
+            "LPT4",
+            "LPT5",
+            "LPT6",
+            "LPT7",
+            "LPT8",
+            "LPT9",
+        }
+        if clean_name.upper() in reserved:
+            clean_name = f"_{clean_name}_"
+        return clean_name.rstrip(". ")[:80]

--- a/app/views/__init__.py
+++ b/app/views/__init__.py
@@ -1,0 +1,1 @@
+"""Package for the desktop recorder application."""

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,16 @@
+# Arquitectura de la aplicación
+
+Esta es una **aplicación de escritorio** construida con Tkinter y ttkbootstrap.
+El código se organiza siguiendo un esquema estilo MVC:
+
+- `app/controllers`: contiene los controladores que orquestan el flujo entre
+  la interfaz y los servicios.
+- `app/services`: encapsula la lógica de negocio reutilizable (historiales,
+  interacción con Chrome y utilidades de nombres).
+- `app/daos`: se encarga del acceso a los datos, actualmente mediante archivos
+  JSON que funcionan como historiales locales.
+- `app/dtos`: define los objetos de transferencia que viajan entre capas.
+- `app/views`: concentra las vistas de la interfaz gráfica.
+
+El punto de entrada de la aplicación es `main.py`, que inicializa la interfaz
+principal ubicada en `app/views/main_view.py`.

--- a/iniciar_pruebas.bat
+++ b/iniciar_pruebas.bat
@@ -2,7 +2,7 @@
 setlocal
 cd /d "%~dp0"
 
-set GUI_FILE=gui_recorder_collect_inputs_modern.py
+set GUI_FILE=main.py
 
 where py >NUL 2>NUL
 if %ERRORLEVEL%==0 (

--- a/main.py
+++ b/main.py
@@ -1,0 +1,7 @@
+"""Application entry point for the desktop recorder UI."""
+
+from app.views.main_view import run_gui
+
+
+if __name__ == "__main__":
+    run_gui()


### PR DESCRIPTION
## Summary
- move the legacy GUI into the app/views package and expose a main entry point
- introduce controllers, services, DAOs and DTOs to separate history and browser logic
- document the new desktop architecture and update the launcher script

## Testing
- python -m compileall app main.py

------
https://chatgpt.com/codex/tasks/task_e_68e9654cc8f0832c98088a34c1af861c