### PR TITLE
Store session artifacts in AppData WebRecord directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 # Changelog
 
-## [0.5.1] - 2024-05-30
-### Changed
-- Los reportes de sesiones y la evidencia capturada se guardan ahora en `%APPDATA%\WebRecord` para separar la configuración del código fuente.
-- El caché de credenciales continúa ubicándose en `%APPDATA%\ForgeBuild\login_cache.json` para conservar la compatibilidad con la herramienta hermana.
-
 ## [0.5.0] - 2024-05-29
 ### Added
 - Tabla `dbo.history_entries` documentada en `docs/database_schema.md` para centralizar los historiales de la aplicación.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.5.1] - 2024-05-30
+### Changed
+- Los reportes de sesiones y la evidencia capturada se guardan ahora en `%APPDATA%\WebRecord` para separar la configuración del código fuente.
+- El caché de credenciales continúa ubicándose en `%APPDATA%\ForgeBuild\login_cache.json` para conservar la compatibilidad con la herramienta hermana.
+
 ## [0.5.0] - 2024-05-29
 ### Added
 - Tabla `dbo.history_entries` documentada en `docs/database_schema.md` para centralizar los historiales de la aplicación.

--- a/app/config/storage_paths.py
+++ b/app/config/storage_paths.py
@@ -1,0 +1,59 @@
+"""Helpers to resolve shared storage directories for the desktop app."""
+
+import os
+from pathlib import Path
+
+
+APP_FOLDER_NAME = "WebRecord"
+LEGACY_APP_FOLDER_NAME = "ForgeBuild"
+SESSIONS_FOLDER_NAME = "sessions"
+EVIDENCE_FOLDER_NAME = "evidencia"
+LOGIN_CACHE_FILENAME = "login_cache.json"
+
+
+def _resolveAppDataBase() -> Path:
+    """Return the root AppData directory on the current system."""
+
+    base_path = os.environ.get("APPDATA")
+    if base_path:
+        return Path(base_path)
+    return Path.home() / "AppData" / "Roaming"
+
+
+def getAppDataRoot() -> Path:
+    """Return the base directory inside AppData reserved for the app."""
+
+    return _resolveAppDataBase() / APP_FOLDER_NAME
+
+
+def getForgeBuildRoot() -> Path:
+    """Return the legacy ForgeBuild directory inside AppData."""
+
+    return _resolveAppDataBase() / LEGACY_APP_FOLDER_NAME
+
+
+def getSessionsDirectory(create: bool = True) -> Path:
+    """Return the folder used to store generated session documents."""
+
+    directory = getAppDataRoot() / SESSIONS_FOLDER_NAME
+    if create:
+        directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def getEvidenceDirectory(create: bool = True) -> Path:
+    """Return the folder that keeps evidence assets like screenshots."""
+
+    directory = getAppDataRoot() / EVIDENCE_FOLDER_NAME
+    if create:
+        directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def getLoginCachePath(create_parent: bool = True) -> Path:
+    """Return the path for the cached login credentials JSON file."""
+
+    path = getForgeBuildRoot() / LOGIN_CACHE_FILENAME
+    if create_parent:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    return path

--- a/app/controllers/main_controller.py
+++ b/app/controllers/main_controller.py
@@ -1,10 +1,14 @@
 """Controller coordinating the desktop view with domain services."""
 
 import json
-import os
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from app.config.storage_paths import (
+    getEvidenceDirectory,
+    getLoginCachePath,
+    getSessionsDirectory,
+)
 from app.daos.database import DatabaseConnector
 from app.daos.history_dao import HistoryDAO
 from app.daos.user_dao import UserDAO, UserDAOError
@@ -23,9 +27,10 @@ class MainController:
     URL_HISTORY_CATEGORY = "desktop-url-history"
     CONFLUENCE_HISTORY_CATEGORY = "desktop-confluence-history"
     CONFLUENCE_SPACES_CATEGORY = "desktop-confluence-space-history"
-    LOGIN_CACHE_PATH = Path(
-        os.environ.get("APPDATA", Path.home() / "AppData" / "Roaming")
-    ) / "ForgeBuild" / "login_cache.json"
+    LOGIN_CACHE_PATH = getLoginCachePath()
+
+    SESSIONS_DIR = getSessionsDirectory()
+    EVIDENCE_DIR = getEvidenceDirectory()
 
     def __init__(self) -> None:
         """Bootstrap all services used by the desktop application."""
@@ -63,6 +68,16 @@ class MainController:
     def get_authenticated_user(self) -> Optional[AuthenticationResult]:
         """Return the cached authenticated user, if any."""
         return self._authenticated_user
+
+    def getSessionsDirectory(self) -> Path:
+        """Provide the storage folder for generated session documents."""
+
+        return self.SESSIONS_DIR
+
+    def getEvidenceDirectory(self) -> Path:
+        """Provide the storage folder for evidence artifacts."""
+
+        return self.EVIDENCE_DIR
 
     def list_active_users(self) -> Tuple[List[Tuple[str, str]], Optional[str]]:
         """Fetch the username/display name pairs available for selection."""

--- a/app/views/main_view.py
+++ b/app/views/main_view.py
@@ -1242,12 +1242,15 @@ def run_gui():
     tb.Label(card2, text="Carpeta evidencias").grid(row=1, column=0, sticky=W, pady=(6,0))
     ev_var = tb.StringVar(); tb.Entry(card2, textvariable=ev_var).grid(row=1, column=1, sticky=EW, padx=(10,0) , pady=(2,2))
 
+    sessions_dir = controller.getSessionsDirectory()
+    evidence_dir = controller.getEvidenceDirectory()
+
     def refresh_paths(*_):
         """Auto-generated docstring for `refresh_paths`."""
         base = controller.slugify_for_windows(base_var.get() or "reporte")
         final = f"{base}"
-        doc_var.set(str(Path("sessions")/f"{final}.docx"))
-        ev_var.set(str(Path("evidencia")/final))
+        doc_var.set(str(sessions_dir / f"{final}.docx"))
+        ev_var.set(str(evidence_dir / final))
     base_var.trace_add("write", refresh_paths); refresh_paths()
 
     prev_base = {"val": controller.slugify_for_windows(base_var.get() or "reporte")}
@@ -1257,7 +1260,7 @@ def run_gui():
         old_base = prev_base["val"]
         if not old_base or new_base == old_base:
             return
-        ev_old = Path("evidencia")/old_base
+        ev_old = evidence_dir / old_base
         has_hist = bool(session.get("steps")) if isinstance(session, dict) else False
         has_old_dir = ev_old.exists()
         if has_hist or has_old_dir:
@@ -1465,7 +1468,7 @@ def run_gui():
 
         status.set("⏳ Preparando contenido y abriendo Confluence...")
         controller.open_chrome_with_profile(url_c, "Default")
-        log_path = Path("sessions") / f"{session.get('title')}_confluence.log"
+        log_path = sessions_dir / f"{session.get('title')}_confluence.log"
 
         Messagebox.showinfo(
             "Confluence",


### PR DESCRIPTION
## Summary
- route session documents and evidence captures into %APPDATA%\WebRecord while keeping the login cache in %APPDATA%\ForgeBuild
- add shared storage path helpers and expose directories through the main controller
- update the view defaults to point to the new application data folders and record the change in the changelog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f80a458fbc832c99c959fa6ab91172