### PR TITLE
Add evidence session persistence with timer controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.6.0] - 2024-05-30
+### Added
+- Tablas `dbo.recorder_sessions`, `dbo.recorder_session_evidences` y `dbo.recorder_session_pauses` documentadas en `docs/database_schema.md` para registrar sesiones, evidencias y pausas desde la aplicación de escritorio.
+- DAOs, DTOs y el `SessionService` para crear sesiones, capturar evidencias, registrar pausas y calcular los tiempos de duración.
+- Controles en la GUI para iniciar, pausar/reanudar y finalizar sesiones con un cronómetro en vivo, listado de evidencias y botón para editar capturas existentes.
+- Pruebas unitarias de `SessionService` que validan el flujo principal sin requerir conexión a SQL Server.
+
+### Changed
+- La generación de reportes y la edición de evidencias actualizan las rutas de salida en la sesión activa para mantener sincronizado el almacenamiento.
+
 ## [0.5.1] - 2024-05-29
 ### Fixed
 - Normalizada la integración con los cuadros de diálogo para que usen `ttkbootstrap` cuando está disponible y hagan `fallback` a Tkinter, evitando excepciones `AttributeError` y asegurando que los mensajes solo aparezcan en pantalla.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Changed
 - La generación de reportes y la edición de evidencias actualizan las rutas de salida en la sesión activa para mantener sincronizado el almacenamiento.
 
+### Fixed
+- Se corrigió el enlace de los campos de salida para que inicialicen correctamente el seguimiento de la sesión y eviten errores al arrancar la aplicación.
+
 ## [0.5.1] - 2024-05-29
 ### Fixed
 - Normalizada la integración con los cuadros de diálogo para que usen `ttkbootstrap` cuando está disponible y hagan `fallback` a Tkinter, evitando excepciones `AttributeError` y asegurando que los mensajes solo aparezcan en pantalla.

--- a/app/controllers/main_controller.py
+++ b/app/controllers/main_controller.py
@@ -11,12 +11,17 @@ from app.config.storage_paths import (
 )
 from app.daos.database import DatabaseConnector
 from app.daos.history_dao import HistoryDAO
+from app.daos.evidence_dao import SessionEvidenceDAO
+from app.daos.session_dao import SessionDAO
+from app.daos.session_pause_dao import SessionPauseDAO
 from app.daos.user_dao import UserDAO, UserDAOError
 from app.dtos.auth_result import AuthenticationResult, AuthenticationStatus
+from app.dtos.session_dto import SessionDTO, SessionEvidenceDTO
 from app.services.auth_service import AuthService
 from app.services.browser_service import BrowserService
 from app.services.history_service import HistoryService
 from app.services.naming_service import NamingService
+from app.services.session_service import SessionService, SessionServiceError
 
 
 class MainController:
@@ -34,12 +39,20 @@ class MainController:
 
     def __init__(self) -> None:
         """Bootstrap all services used by the desktop application."""
-        self._history_service = HistoryService(HistoryDAO(DatabaseConnector().connection_factory()))
+        history_connector = DatabaseConnector().connection_factory()
+        self._history_service = HistoryService(HistoryDAO(history_connector))
         self._browser_service = BrowserService()
         self._naming_service = NamingService()
-        self._user_dao = UserDAO(DatabaseConnector().connection_factory())
+        user_connector = DatabaseConnector().connection_factory()
+        self._user_dao = UserDAO(user_connector)
         self._auth_service = AuthService(self._user_dao)
         self._authenticated_user: Optional[AuthenticationResult] = None
+        session_connector = DatabaseConnector().connection_factory()
+        self._session_service = SessionService(
+            SessionDAO(session_connector),
+            SessionEvidenceDAO(session_connector),
+            SessionPauseDAO(session_connector),
+        )
 
     def load_history(self, category: str, default_value: str) -> List[str]:
         """Return the stored history values for a logical category."""
@@ -78,6 +91,110 @@ class MainController:
         """Provide the storage folder for evidence artifacts."""
 
         return self.EVIDENCE_DIR
+
+    def begin_evidence_session(
+        self,
+        name: str,
+        initial_url: str,
+        docx_url: str,
+        evidences_url: str,
+    ) -> Tuple[Optional[SessionDTO], Optional[str]]:
+        """Start a new evidence session for the authenticated user."""
+
+        if not self._authenticated_user:
+            return None, "Debes iniciar sesión antes de crear una sesión de evidencias."
+        username = self._authenticated_user.username or ""
+        try:
+            session = self._session_service.begin_session(name, initial_url, docx_url, evidences_url, username)
+        except SessionServiceError as exc:
+            return None, str(exc)
+        return session, None
+
+    def update_active_session_outputs(self, docx_url: str, evidences_url: str) -> Optional[str]:
+        """Persist the output locations for the active session if available."""
+
+        try:
+            self._session_service.update_outputs(docx_url, evidences_url)
+        except SessionServiceError as exc:
+            return str(exc)
+        return None
+
+    def get_active_session(self) -> Optional[SessionDTO]:
+        """Expose the active session DTO to the view layer."""
+
+        return self._session_service.get_active_session()
+
+    def get_session_elapsed_seconds(self) -> int:
+        """Return the total elapsed seconds for the active session."""
+
+        return self._session_service.get_elapsed_seconds()
+
+    def pause_evidence_session(self) -> Optional[str]:
+        """Pause the active session timer."""
+
+        try:
+            self._session_service.pause_session()
+        except SessionServiceError as exc:
+            return str(exc)
+        return None
+
+    def resume_evidence_session(self) -> Optional[str]:
+        """Resume the session timer after a pause."""
+
+        try:
+            self._session_service.resume_session()
+        except SessionServiceError as exc:
+            return str(exc)
+        return None
+
+    def finalize_evidence_session(self) -> Tuple[Optional[SessionDTO], Optional[str]]:
+        """Finalize the active session and return the stored DTO."""
+
+        try:
+            session = self._session_service.finalize_session()
+        except SessionServiceError as exc:
+            return None, str(exc)
+        return session, None
+
+    def register_session_evidence(
+        self,
+        file_path: Path,
+        description: str,
+        considerations: str,
+        observations: str,
+    ) -> Tuple[Optional[SessionEvidenceDTO], Optional[str]]:
+        """Store a captured evidence in the active session."""
+
+        try:
+            evidence = self._session_service.record_evidence(file_path, description, considerations, observations)
+        except SessionServiceError as exc:
+            return None, str(exc)
+        return evidence, None
+
+    def list_session_evidences(self) -> Tuple[List[SessionEvidenceDTO], Optional[str]]:
+        """Return the evidences recorded in the active session."""
+
+        try:
+            evidences = self._session_service.list_evidences()
+        except SessionServiceError as exc:
+            return [], str(exc)
+        return evidences, None
+
+    def update_session_evidence(
+        self,
+        evidence_id: int,
+        file_path: Path,
+        description: str,
+        considerations: str,
+        observations: str,
+    ) -> Optional[str]:
+        """Update metadata or the file path for an existing evidence."""
+
+        try:
+            self._session_service.update_evidence(evidence_id, file_path, description, considerations, observations)
+        except SessionServiceError as exc:
+            return str(exc)
+        return None
 
     def list_active_users(self) -> Tuple[List[Tuple[str, str]], Optional[str]]:
         """Fetch the username/display name pairs available for selection."""

--- a/app/daos/evidence_dao.py
+++ b/app/daos/evidence_dao.py
@@ -1,0 +1,234 @@
+"""Data access helpers for session evidences."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Iterable, List
+
+if TYPE_CHECKING:  # pragma: no cover - only used for typing
+    import pymssql
+
+from app.daos.database import DatabaseConnectorError
+from app.dtos.session_dto import SessionEvidenceDTO
+
+
+class SessionEvidenceDAOError(RuntimeError):
+    """Raised when evidence records cannot be persisted or read."""
+
+
+class SessionEvidenceDAO:
+    """Provide CRUD operations for evidences captured during a session."""
+
+    def __init__(self, connection_factory: Callable[[], "pymssql.Connection"]) -> None:
+        """Store the connection factory used to talk with SQL Server."""
+
+        self._connection_factory = connection_factory
+        self._schema_ready = False
+
+    def _ensure_schema(self) -> None:
+        """Create the evidences table the first time it is required."""
+
+        if self._schema_ready:
+            return
+
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionEvidenceDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.tables t
+                    INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+                    WHERE t.name = 'recorder_session_evidences' AND s.name = 'dbo'
+                )
+                BEGIN
+                    CREATE TABLE dbo.recorder_session_evidences (
+                        evidence_id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+                        session_id INT NOT NULL,
+                        file_name NVARCHAR(512) NOT NULL,
+                        file_path NVARCHAR(2048) NOT NULL,
+                        description NVARCHAR(MAX) NULL,
+                        considerations NVARCHAR(MAX) NULL,
+                        observations NVARCHAR(MAX) NULL,
+                        created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+                        updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+                        elapsed_since_session_start_seconds INT NOT NULL DEFAULT 0,
+                        elapsed_since_previous_evidence_seconds INT NULL,
+                        CONSTRAINT fk_recorder_evidences_session FOREIGN KEY (session_id)
+                            REFERENCES dbo.recorder_sessions(session_id) ON DELETE CASCADE
+                    );
+                    CREATE INDEX ix_recorder_session_evidences_session_created
+                        ON dbo.recorder_session_evidences (session_id, created_at ASC, evidence_id ASC);
+                END
+                """
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            raise SessionEvidenceDAOError("No fue posible preparar la tabla de evidencias.") from exc
+        finally:
+            connection.close()
+
+        self._schema_ready = True
+
+    def create_evidence(
+        self,
+        session_id: int,
+        file_name: str,
+        file_path: str,
+        description: str,
+        considerations: str,
+        observations: str,
+        created_at: datetime,
+        elapsed_since_start: int,
+        elapsed_since_previous: int | None,
+    ) -> SessionEvidenceDTO:
+        """Insert a new evidence row linked to the provided session."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionEvidenceDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "INSERT INTO dbo.recorder_session_evidences "
+                    "(session_id, file_name, file_path, description, considerations, observations, created_at, updated_at, "
+                    "elapsed_since_session_start_seconds, elapsed_since_previous_evidence_seconds) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s); "
+                    "SELECT CAST(SCOPE_IDENTITY() AS INT);"
+                ),
+                (
+                    session_id,
+                    file_name,
+                    file_path,
+                    description,
+                    considerations,
+                    observations,
+                    created_at,
+                    created_at,
+                    elapsed_since_start,
+                    elapsed_since_previous,
+                ),
+            )
+            row = cursor.fetchone()
+            connection.commit()
+        except Exception as exc:  # pragma: no cover
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise SessionEvidenceDAOError("No fue posible guardar la evidencia capturada.") from exc
+
+        connection.close()
+        evidence_id = int(row[0]) if row and row[0] is not None else None
+        return SessionEvidenceDTO(
+            evidenceId=evidence_id,
+            sessionId=session_id,
+            fileName=file_name,
+            filePath=file_path,
+            description=description,
+            considerations=considerations,
+            observations=observations,
+            createdAt=created_at,
+            updatedAt=created_at,
+            elapsedSinceSessionStartSeconds=elapsed_since_start,
+            elapsedSincePreviousEvidenceSeconds=elapsed_since_previous,
+        )
+
+    def update_evidence(
+        self,
+        evidence_id: int,
+        file_name: str,
+        file_path: str,
+        description: str,
+        considerations: str,
+        observations: str,
+        updated_at: datetime,
+    ) -> None:
+        """Persist metadata or path changes for an existing evidence."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionEvidenceDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "UPDATE dbo.recorder_session_evidences "
+                    "SET file_name = %s, file_path = %s, description = %s, considerations = %s, observations = %s, updated_at = %s "
+                    "WHERE evidence_id = %s"
+                ),
+                (file_name, file_path, description, considerations, observations, updated_at, evidence_id),
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise SessionEvidenceDAOError("No fue posible actualizar la evidencia seleccionada.") from exc
+
+        connection.close()
+
+    def list_by_session(self, session_id: int) -> List[SessionEvidenceDTO]:
+        """Return all evidences recorded for the given session."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionEvidenceDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "SELECT evidence_id, session_id, file_name, file_path, description, considerations, observations, created_at, updated_at, "
+                    "elapsed_since_session_start_seconds, elapsed_since_previous_evidence_seconds "
+                    "FROM dbo.recorder_session_evidences WHERE session_id = %s "
+                    "ORDER BY created_at ASC, evidence_id ASC"
+                ),
+                (session_id,),
+            )
+            rows: Iterable[Iterable[object]] = cursor.fetchall() or []
+        except Exception as exc:  # pragma: no cover
+            connection.close()
+            raise SessionEvidenceDAOError("No fue posible leer las evidencias registradas.") from exc
+
+        connection.close()
+        evidences: List[SessionEvidenceDTO] = []
+        for row in rows:
+            created_at = row[7] if isinstance(row[7], datetime) else datetime.fromisoformat(str(row[7]))
+            updated_at = row[8] if isinstance(row[8], datetime) else datetime.fromisoformat(str(row[8]))
+            evidences.append(
+                SessionEvidenceDTO(
+                    evidenceId=int(row[0]) if row[0] is not None else None,
+                    sessionId=int(row[1]) if row[1] is not None else session_id,
+                    fileName=str(row[2] or ""),
+                    filePath=str(row[3] or ""),
+                    description=str(row[4] or ""),
+                    considerations=str(row[5] or ""),
+                    observations=str(row[6] or ""),
+                    createdAt=created_at,
+                    updatedAt=updated_at,
+                    elapsedSinceSessionStartSeconds=int(row[9] or 0),
+                    elapsedSincePreviousEvidenceSeconds=(int(row[10]) if row[10] is not None else None),
+                )
+            )
+        return evidences

--- a/app/daos/session_dao.py
+++ b/app/daos/session_dao.py
@@ -1,0 +1,240 @@
+"""Data access helpers for recorder sessions."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - only used for typing
+    import pymssql
+
+from app.daos.database import DatabaseConnectorError
+from app.dtos.session_dto import SessionDTO
+
+
+class SessionDAOError(RuntimeError):
+    """Raised when the session storage cannot be accessed."""
+
+
+class SessionDAO:
+    """Provide CRUD operations for recorder sessions."""
+
+    def __init__(self, connection_factory: Callable[[], "pymssql.Connection"]) -> None:
+        """Store the callable used to obtain database connections."""
+
+        self._connection_factory = connection_factory
+        self._schema_ready = False
+
+    def _ensure_schema(self) -> None:
+        """Create the sessions table on first use."""
+
+        if self._schema_ready:
+            return
+
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depends on environment
+            raise SessionDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.tables t
+                    INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+                    WHERE t.name = 'recorder_sessions' AND s.name = 'dbo'
+                )
+                BEGIN
+                    CREATE TABLE dbo.recorder_sessions (
+                        session_id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+                        name NVARCHAR(255) NOT NULL,
+                        initial_url NVARCHAR(2048) NULL,
+                        docx_url NVARCHAR(2048) NULL,
+                        evidences_url NVARCHAR(2048) NULL,
+                        duration_seconds INT NOT NULL DEFAULT 0,
+                        started_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+                        ended_at DATETIME2(0) NULL,
+                        username NVARCHAR(255) NOT NULL,
+                        created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+                        updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME()
+                    );
+                    CREATE INDEX ix_recorder_sessions_started_at
+                        ON dbo.recorder_sessions (started_at DESC, session_id DESC);
+                END
+                """
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depends on driver
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            raise SessionDAOError("No fue posible preparar la tabla de sesiones.") from exc
+        finally:
+            connection.close()
+
+        self._schema_ready = True
+
+    def create_session(
+        self,
+        name: str,
+        initial_url: str,
+        docx_url: str,
+        evidences_url: str,
+        username: str,
+        started_at: datetime,
+    ) -> SessionDTO:
+        """Insert a new session row and return the created DTO."""
+
+        self._ensure_schema()
+        created_at = started_at
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "INSERT INTO dbo.recorder_sessions "
+                    "(name, initial_url, docx_url, evidences_url, duration_seconds, started_at, ended_at, username, created_at, updated_at) "
+                    "VALUES (%s, %s, %s, %s, 0, %s, NULL, %s, %s, %s); "
+                    "SELECT CAST(SCOPE_IDENTITY() AS INT);"
+                ),
+                (name, initial_url, docx_url, evidences_url, started_at, username, created_at, created_at),
+            )
+            row = cursor.fetchone()
+            connection.commit()
+        except Exception as exc:  # pragma: no cover
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise SessionDAOError("No fue posible registrar la sesión de evidencias.") from exc
+
+        connection.close()
+        session_id = int(row[0]) if row and row[0] is not None else None
+        return SessionDTO(
+            sessionId=session_id,
+            name=name,
+            initialUrl=initial_url,
+            docxUrl=docx_url,
+            evidencesUrl=evidences_url,
+            durationSeconds=0,
+            startedAt=started_at,
+            endedAt=None,
+            username=username,
+            createdAt=created_at,
+            updatedAt=created_at,
+        )
+
+    def update_outputs(
+        self,
+        session_id: int,
+        docx_url: str,
+        evidences_url: str,
+        updated_at: datetime,
+    ) -> None:
+        """Persist the latest output locations for an active session."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "UPDATE dbo.recorder_sessions "
+                    "SET docx_url = %s, evidences_url = %s, updated_at = %s "
+                    "WHERE session_id = %s"
+                ),
+                (docx_url, evidences_url, updated_at, session_id),
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise SessionDAOError("No fue posible actualizar las rutas de la sesión.") from exc
+
+        connection.close()
+
+    def close_session(self, session_id: int, ended_at: datetime, duration_seconds: int) -> None:
+        """Mark a session as finished and store the total duration."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "UPDATE dbo.recorder_sessions "
+                    "SET ended_at = %s, duration_seconds = %s, updated_at = %s "
+                    "WHERE session_id = %s"
+                ),
+                (ended_at, duration_seconds, ended_at, session_id),
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise SessionDAOError("No fue posible finalizar la sesión de evidencias.") from exc
+
+        connection.close()
+
+    def get_session(self, session_id: int) -> Optional[SessionDTO]:
+        """Fetch a session row to refresh the cached DTO."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "SELECT session_id, name, initial_url, docx_url, evidences_url, duration_seconds, "
+                    "started_at, ended_at, username, created_at, updated_at "
+                    "FROM dbo.recorder_sessions WHERE session_id = %s"
+                ),
+                (session_id,),
+            )
+            row = cursor.fetchone()
+        except Exception as exc:  # pragma: no cover
+            connection.close()
+            raise SessionDAOError("No fue posible consultar la sesión solicitada.") from exc
+
+        connection.close()
+        if not row:
+            return None
+
+        return SessionDTO(
+            sessionId=int(row[0]) if row[0] is not None else None,
+            name=str(row[1] or ""),
+            initialUrl=str(row[2] or ""),
+            docxUrl=str(row[3] or ""),
+            evidencesUrl=str(row[4] or ""),
+            durationSeconds=int(row[5] or 0),
+            startedAt=row[6] if isinstance(row[6], datetime) else datetime.fromisoformat(str(row[6])),
+            endedAt=row[7] if isinstance(row[7], datetime) or row[7] is None else datetime.fromisoformat(str(row[7])),
+            username=str(row[8] or ""),
+            createdAt=row[9] if isinstance(row[9], datetime) else datetime.fromisoformat(str(row[9])),
+            updatedAt=row[10] if isinstance(row[10], datetime) else datetime.fromisoformat(str(row[10])),
+        )

--- a/app/daos/session_pause_dao.py
+++ b/app/daos/session_pause_dao.py
@@ -1,0 +1,198 @@
+"""Data access helpers for session pause intervals."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Iterable, List
+
+if TYPE_CHECKING:  # pragma: no cover - only used for typing
+    import pymssql
+
+from app.daos.database import DatabaseConnectorError
+from app.dtos.session_dto import SessionPauseDTO
+
+
+class SessionPauseDAOError(RuntimeError):
+    """Raised when pause intervals cannot be persisted or read."""
+
+
+class SessionPauseDAO:
+    """Provide CRUD operations for pauses within a session."""
+
+    def __init__(self, connection_factory: Callable[[], "pymssql.Connection"]) -> None:
+        """Store the callable used to open database connections."""
+
+        self._connection_factory = connection_factory
+        self._schema_ready = False
+
+    def _ensure_schema(self) -> None:
+        """Create the pauses table on demand."""
+
+        if self._schema_ready:
+            return
+
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionPauseDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.tables t
+                    INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+                    WHERE t.name = 'recorder_session_pauses' AND s.name = 'dbo'
+                )
+                BEGIN
+                    CREATE TABLE dbo.recorder_session_pauses (
+                        pause_id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+                        session_id INT NOT NULL,
+                        paused_at DATETIME2(0) NOT NULL,
+                        resumed_at DATETIME2(0) NULL,
+                        elapsed_seconds_when_paused INT NOT NULL DEFAULT 0,
+                        pause_duration_seconds INT NULL,
+                        CONSTRAINT fk_recorder_session_pauses_session FOREIGN KEY (session_id)
+                            REFERENCES dbo.recorder_sessions(session_id) ON DELETE CASCADE
+                    );
+                    CREATE INDEX ix_recorder_session_pauses_session
+                        ON dbo.recorder_session_pauses (session_id, paused_at DESC, pause_id DESC);
+                END
+                """
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            raise SessionPauseDAOError("No fue posible preparar la tabla de pausas.") from exc
+        finally:
+            connection.close()
+
+        self._schema_ready = True
+
+    def create_pause(
+        self,
+        session_id: int,
+        paused_at: datetime,
+        elapsed_seconds_when_paused: int,
+    ) -> SessionPauseDTO:
+        """Insert a new pause row associated with the provided session."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionPauseDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "INSERT INTO dbo.recorder_session_pauses "
+                    "(session_id, paused_at, resumed_at, elapsed_seconds_when_paused, pause_duration_seconds) "
+                    "VALUES (%s, %s, NULL, %s, NULL); "
+                    "SELECT CAST(SCOPE_IDENTITY() AS INT);"
+                ),
+                (session_id, paused_at, elapsed_seconds_when_paused),
+            )
+            row = cursor.fetchone()
+            connection.commit()
+        except Exception as exc:  # pragma: no cover
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise SessionPauseDAOError("No fue posible registrar la pausa de la sesión.") from exc
+
+        connection.close()
+        pause_id = int(row[0]) if row and row[0] is not None else None
+        return SessionPauseDTO(
+            pauseId=pause_id,
+            sessionId=session_id,
+            pausedAt=paused_at,
+            resumedAt=None,
+            elapsedSecondsWhenPaused=elapsed_seconds_when_paused,
+            pauseDurationSeconds=None,
+        )
+
+    def finish_pause(
+        self,
+        pause_id: int,
+        resumed_at: datetime,
+        pause_duration_seconds: int,
+    ) -> None:
+        """Update the pause row once the session is resumed."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionPauseDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "UPDATE dbo.recorder_session_pauses "
+                    "SET resumed_at = %s, pause_duration_seconds = %s "
+                    "WHERE pause_id = %s"
+                ),
+                (resumed_at, pause_duration_seconds, pause_id),
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise SessionPauseDAOError("No fue posible actualizar la pausa de la sesión.") from exc
+
+        connection.close()
+
+    def list_by_session(self, session_id: int) -> List[SessionPauseDTO]:
+        """Return the pauses registered for the given session."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise SessionPauseDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "SELECT pause_id, session_id, paused_at, resumed_at, elapsed_seconds_when_paused, pause_duration_seconds "
+                    "FROM dbo.recorder_session_pauses WHERE session_id = %s "
+                    "ORDER BY paused_at DESC, pause_id DESC"
+                ),
+                (session_id,),
+            )
+            rows: Iterable[Iterable[object]] = cursor.fetchall() or []
+        except Exception as exc:  # pragma: no cover
+            connection.close()
+            raise SessionPauseDAOError("No fue posible obtener las pausas de la sesión.") from exc
+
+        connection.close()
+        pauses: List[SessionPauseDTO] = []
+        for row in rows:
+            paused_at = row[2] if isinstance(row[2], datetime) else datetime.fromisoformat(str(row[2]))
+            resumed_at = None
+            if row[3] is not None:
+                resumed_at = row[3] if isinstance(row[3], datetime) else datetime.fromisoformat(str(row[3]))
+            pauses.append(
+                SessionPauseDTO(
+                    pauseId=int(row[0]) if row[0] is not None else None,
+                    sessionId=int(row[1]) if row[1] is not None else session_id,
+                    pausedAt=paused_at,
+                    resumedAt=resumed_at,
+                    elapsedSecondsWhenPaused=int(row[4] or 0),
+                    pauseDurationSeconds=(int(row[5]) if row[5] is not None else None),
+                )
+            )
+        return pauses

--- a/app/dtos/session_dto.py
+++ b/app/dtos/session_dto.py
@@ -1,0 +1,53 @@
+"""Data transfer objects for recorder sessions and related artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class SessionDTO:
+    """Represent a persisted recorder session."""
+
+    sessionId: Optional[int]
+    name: str
+    initialUrl: str
+    docxUrl: str
+    evidencesUrl: str
+    durationSeconds: int
+    startedAt: datetime
+    endedAt: Optional[datetime]
+    username: str
+    createdAt: datetime
+    updatedAt: datetime
+
+
+@dataclass
+class SessionEvidenceDTO:
+    """Represent a single evidence captured within a recorder session."""
+
+    evidenceId: Optional[int]
+    sessionId: int
+    fileName: str
+    filePath: str
+    description: str
+    considerations: str
+    observations: str
+    createdAt: datetime
+    updatedAt: datetime
+    elapsedSinceSessionStartSeconds: int
+    elapsedSincePreviousEvidenceSeconds: Optional[int]
+
+
+@dataclass
+class SessionPauseDTO:
+    """Represent a pause interval registered for a recorder session."""
+
+    pauseId: Optional[int]
+    sessionId: int
+    pausedAt: datetime
+    resumedAt: Optional[datetime]
+    elapsedSecondsWhenPaused: int
+    pauseDurationSeconds: Optional[int]

--- a/app/services/session_service.py
+++ b/app/services/session_service.py
@@ -1,0 +1,279 @@
+"""Business logic to orchestrate evidence recording sessions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+from app.daos.evidence_dao import SessionEvidenceDAO, SessionEvidenceDAOError
+from app.daos.session_dao import SessionDAO, SessionDAOError
+from app.daos.session_pause_dao import SessionPauseDAO, SessionPauseDAOError
+from app.dtos.session_dto import SessionDTO, SessionEvidenceDTO, SessionPauseDTO
+
+
+logger = logging.getLogger(__name__)
+
+
+class SessionServiceError(RuntimeError):
+    """Raised when a session-level operation cannot be completed."""
+
+
+@dataclass
+class ActiveSessionState:
+    """Track runtime information for the session timer."""
+
+    session: SessionDTO
+    resumeReference: datetime
+    elapsedSeconds: int
+    lastEvidenceAt: Optional[datetime]
+    activePause: Optional[SessionPauseDTO]
+
+
+class SessionService:
+    """Coordinate session lifecycle, evidences and pause management."""
+
+    def __init__(
+        self,
+        session_dao: SessionDAO,
+        evidence_dao: SessionEvidenceDAO,
+        pause_dao: SessionPauseDAO,
+    ) -> None:
+        """Store the DAO dependencies and reset the active state."""
+
+        self._session_dao = session_dao
+        self._evidence_dao = evidence_dao
+        self._pause_dao = pause_dao
+        self._active_state: Optional[ActiveSessionState] = None
+
+    @staticmethod
+    def _utcnow() -> datetime:
+        """Return the current UTC timestamp with second precision."""
+
+        return datetime.now(timezone.utc).replace(microsecond=0)
+
+    def begin_session(
+        self,
+        name: str,
+        initial_url: str,
+        docx_url: str,
+        evidences_url: str,
+        username: str,
+    ) -> SessionDTO:
+        """Create a new session and keep it as the active one."""
+
+        if self._active_state is not None:
+            raise SessionServiceError("Ya existe una sesión activa. Finalízala antes de iniciar otra.")
+
+        started_at = self._utcnow()
+        try:
+            session = self._session_dao.create_session(name, initial_url, docx_url, evidences_url, username, started_at)
+        except SessionDAOError as exc:
+            logger.error("No fue posible crear la sesión de evidencias: %s", exc)
+            raise SessionServiceError(str(exc)) from exc
+
+        self._active_state = ActiveSessionState(
+            session=session,
+            resumeReference=started_at,
+            elapsedSeconds=0,
+            lastEvidenceAt=None,
+            activePause=None,
+        )
+        return session
+
+    def get_active_session(self) -> Optional[SessionDTO]:
+        """Return the active session DTO, if any."""
+
+        if not self._active_state:
+            return None
+        return self._active_state.session
+
+    def update_outputs(self, docx_url: str, evidences_url: str) -> None:
+        """Persist the latest output locations if a session is active."""
+
+        if not self._active_state:
+            return
+        updated_at = self._utcnow()
+        session = self._active_state.session
+        try:
+            self._session_dao.update_outputs(session.sessionId or 0, docx_url, evidences_url, updated_at)
+        except SessionDAOError as exc:
+            logger.error("No se pudieron actualizar las rutas de la sesión %s: %s", session.sessionId, exc)
+            raise SessionServiceError(str(exc)) from exc
+        refreshed = self._session_dao.get_session(session.sessionId or 0)
+        if refreshed:
+            self._active_state.session = refreshed
+
+    def get_elapsed_seconds(self) -> int:
+        """Compute the total elapsed seconds for the active session."""
+
+        if not self._active_state:
+            return 0
+        state = self._active_state
+        elapsed = state.elapsedSeconds
+        if state.activePause is None and state.resumeReference:
+            now = self._utcnow()
+            elapsed += max(0, int((now - state.resumeReference).total_seconds()))
+        return elapsed
+
+    def _ensure_session_running(self) -> ActiveSessionState:
+        """Return the active state ensuring the session is running."""
+
+        if self._active_state is None:
+            raise SessionServiceError("No hay una sesión activa en curso.")
+        return self._active_state
+
+    def pause_session(self) -> SessionPauseDTO:
+        """Register a pause and freeze the timer."""
+
+        state = self._ensure_session_running()
+        if state.activePause is not None:
+            raise SessionServiceError("La sesión ya está en pausa.")
+
+        now = self._utcnow()
+        if state.resumeReference:
+            state.elapsedSeconds += max(0, int((now - state.resumeReference).total_seconds()))
+        try:
+            pause = self._pause_dao.create_pause(state.session.sessionId or 0, now, state.elapsedSeconds)
+        except SessionPauseDAOError as exc:
+            logger.error("No fue posible pausar la sesión %s: %s", state.session.sessionId, exc)
+            raise SessionServiceError(str(exc)) from exc
+
+        state.activePause = pause
+        state.resumeReference = now
+        return pause
+
+    def resume_session(self) -> SessionPauseDTO:
+        """Finish the active pause and resume the timer."""
+
+        state = self._ensure_session_running()
+        pause = state.activePause
+        if pause is None:
+            raise SessionServiceError("La sesión no está en pausa.")
+
+        now = self._utcnow()
+        pause_duration = max(0, int((now - pause.pausedAt).total_seconds()))
+        try:
+            self._pause_dao.finish_pause(pause.pauseId or 0, now, pause_duration)
+        except SessionPauseDAOError as exc:
+            logger.error("No fue posible reanudar la sesión %s: %s", state.session.sessionId, exc)
+            raise SessionServiceError(str(exc)) from exc
+
+        updated_pause = SessionPauseDTO(
+            pauseId=pause.pauseId,
+            sessionId=pause.sessionId,
+            pausedAt=pause.pausedAt,
+            resumedAt=now,
+            elapsedSecondsWhenPaused=pause.elapsedSecondsWhenPaused,
+            pauseDurationSeconds=pause_duration,
+        )
+        state.activePause = None
+        state.resumeReference = now
+        return updated_pause
+
+    def record_evidence(
+        self,
+        file_path: Path,
+        description: str,
+        considerations: str,
+        observations: str,
+    ) -> SessionEvidenceDTO:
+        """Persist a captured evidence and update timer checkpoints."""
+
+        state = self._ensure_session_running()
+        if state.activePause is not None:
+            raise SessionServiceError("No se pueden capturar evidencias mientras la sesión está en pausa.")
+
+        now = self._utcnow()
+        elapsed_since_start = self.get_elapsed_seconds()
+        elapsed_since_previous: Optional[int]
+        if state.lastEvidenceAt is None:
+            elapsed_since_previous = elapsed_since_start
+        else:
+            elapsed_since_previous = max(0, int((now - state.lastEvidenceAt).total_seconds()))
+
+        file_name = file_path.name
+        try:
+            evidence = self._evidence_dao.create_evidence(
+                state.session.sessionId or 0,
+                file_name,
+                str(file_path),
+                description,
+                considerations,
+                observations,
+                now,
+                elapsed_since_start,
+                elapsed_since_previous,
+            )
+        except SessionEvidenceDAOError as exc:
+            logger.error("No se pudo guardar la evidencia para la sesión %s: %s", state.session.sessionId, exc)
+            raise SessionServiceError(str(exc)) from exc
+
+        state.lastEvidenceAt = now
+        return evidence
+
+    def list_evidences(self) -> List[SessionEvidenceDTO]:
+        """Return the evidences stored for the active session."""
+
+        state = self._ensure_session_running()
+        try:
+            evidences = self._evidence_dao.list_by_session(state.session.sessionId or 0)
+        except SessionEvidenceDAOError as exc:
+            logger.error("No se pudieron leer las evidencias de la sesión %s: %s", state.session.sessionId, exc)
+            raise SessionServiceError(str(exc)) from exc
+
+        if evidences:
+            state.lastEvidenceAt = evidences[-1].createdAt
+        return evidences
+
+    def update_evidence(
+        self,
+        evidence_id: int,
+        file_path: Path,
+        description: str,
+        considerations: str,
+        observations: str,
+    ) -> None:
+        """Update the stored metadata for a given evidence."""
+
+        state = self._ensure_session_running()
+        updated_at = self._utcnow()
+        try:
+            self._evidence_dao.update_evidence(
+                evidence_id,
+                file_path.name,
+                str(file_path),
+                description,
+                considerations,
+                observations,
+                updated_at,
+            )
+        except SessionEvidenceDAOError as exc:
+            logger.error("No se pudo actualizar la evidencia %s: %s", evidence_id, exc)
+            raise SessionServiceError(str(exc)) from exc
+
+        # Refresh local cache ordering
+        evidences = self.list_evidences()
+        if evidences:
+            state.lastEvidenceAt = evidences[-1].createdAt
+
+    def finalize_session(self) -> SessionDTO:
+        """Close the active session and persist the duration."""
+
+        state = self._ensure_session_running()
+        if state.activePause is not None:
+            raise SessionServiceError("Reanuda la sesión antes de finalizarla.")
+
+        now = self._utcnow()
+        total_elapsed = self.get_elapsed_seconds()
+        try:
+            self._session_dao.close_session(state.session.sessionId or 0, now, total_elapsed)
+        except SessionDAOError as exc:
+            logger.error("No fue posible finalizar la sesión %s: %s", state.session.sessionId, exc)
+            raise SessionServiceError(str(exc)) from exc
+
+        refreshed = self._session_dao.get_session(state.session.sessionId or 0)
+        self._active_state = None
+        return refreshed or state.session

--- a/app/views/main_view.py
+++ b/app/views/main_view.py
@@ -1351,8 +1351,6 @@ def run_gui():
             prev_base["val"] = new_base
 
     base_var.trace_add("write", _on_base_change)
-    doc_var.trace_add("write", _update_session_outputs)
-    ev_var.trace_add("write", _update_session_outputs)
 
     status = tb.StringVar(value="Listo.")
     status_bar = tb.Label(app, textvariable=status, bootstyle=INFO, anchor=W, padding=(16,6)); status_bar.pack(fill=X)
@@ -1437,6 +1435,9 @@ def run_gui():
         error = controller.update_active_session_outputs(doc_var.get(), ev_var.get())
         if error:
             status.set(f"⚠️ {error}")
+
+    doc_var.trace_add("write", _update_session_outputs)
+    ev_var.trace_add("write", _update_session_outputs)
 
     def _show_elapsed_message() -> None:
         """Display the elapsed time in a dialog."""

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -52,6 +52,56 @@ CREATE TABLE dbo.history_entries (
 CREATE INDEX ix_history_entries_category_created_at
     ON dbo.history_entries (category, created_at DESC, entry_id DESC);
 
+CREATE TABLE dbo.recorder_sessions (
+    session_id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    name NVARCHAR(255) NOT NULL,
+    initial_url NVARCHAR(2048) NULL,
+    docx_url NVARCHAR(2048) NULL,
+    evidences_url NVARCHAR(2048) NULL,
+    duration_seconds INT NOT NULL DEFAULT 0,
+    started_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    ended_at DATETIME2(0) NULL,
+    username NVARCHAR(255) NOT NULL,
+    created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME()
+);
+
+CREATE INDEX ix_recorder_sessions_started_at
+    ON dbo.recorder_sessions (started_at DESC, session_id DESC);
+
+CREATE TABLE dbo.recorder_session_evidences (
+    evidence_id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    session_id INT NOT NULL,
+    file_name NVARCHAR(512) NOT NULL,
+    file_path NVARCHAR(2048) NOT NULL,
+    description NVARCHAR(MAX) NULL,
+    considerations NVARCHAR(MAX) NULL,
+    observations NVARCHAR(MAX) NULL,
+    created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    elapsed_since_session_start_seconds INT NOT NULL DEFAULT 0,
+    elapsed_since_previous_evidence_seconds INT NULL,
+    CONSTRAINT fk_recorder_evidences_session FOREIGN KEY (session_id)
+        REFERENCES dbo.recorder_sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX ix_recorder_session_evidences_session_created
+    ON dbo.recorder_session_evidences (session_id, created_at ASC, evidence_id ASC);
+
+CREATE TABLE dbo.recorder_session_pauses (
+    pause_id INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    session_id INT NOT NULL,
+    paused_at DATETIME2(0) NOT NULL,
+    resumed_at DATETIME2(0) NULL,
+    elapsed_seconds_when_paused INT NOT NULL DEFAULT 0,
+    pause_duration_seconds INT NULL,
+    CONSTRAINT fk_recorder_session_pauses_session FOREIGN KEY (session_id)
+        REFERENCES dbo.recorder_sessions(session_id) ON DELETE CASCADE
+);
+
+CREATE INDEX ix_recorder_session_pauses_session
+    ON dbo.recorder_session_pauses (session_id, paused_at DESC, pause_id DESC);
+
 CREATE TABLE dbo.sprints (
     id INT IDENTITY(1,1) PRIMARY KEY,
     branch_key NVARCHAR(512) NOT NULL DEFAULT '',

--- a/tests/test_session_service.py
+++ b/tests/test_session_service.py
@@ -1,0 +1,210 @@
+"""Unit tests for the session service lifecycle using in-memory doubles."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.dtos.session_dto import SessionDTO, SessionEvidenceDTO, SessionPauseDTO
+from app.services.session_service import SessionService, SessionServiceError
+
+
+class FakeSessionDAO:
+    """Minimal in-memory DAO to emulate recorder sessions."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[int, SessionDTO] = {}
+        self._next_id = 1
+
+    def create_session(
+        self,
+        name: str,
+        initial_url: str,
+        docx_url: str,
+        evidences_url: str,
+        username: str,
+        started_at: datetime,
+    ) -> SessionDTO:
+        session_id = self._next_id
+        self._next_id += 1
+        dto = SessionDTO(
+            sessionId=session_id,
+            name=name,
+            initialUrl=initial_url,
+            docxUrl=docx_url,
+            evidencesUrl=evidences_url,
+            durationSeconds=0,
+            startedAt=started_at,
+            endedAt=None,
+            username=username,
+            createdAt=started_at,
+            updatedAt=started_at,
+        )
+        self._sessions[session_id] = dto
+        return dto
+
+    def update_outputs(self, session_id: int, docx_url: str, evidences_url: str, updated_at: datetime) -> None:
+        dto = self._sessions[session_id]
+        self._sessions[session_id] = replace(dto, docxUrl=docx_url, evidencesUrl=evidences_url, updatedAt=updated_at)
+
+    def close_session(self, session_id: int, ended_at: datetime, duration_seconds: int) -> None:
+        dto = self._sessions[session_id]
+        self._sessions[session_id] = replace(dto, endedAt=ended_at, durationSeconds=duration_seconds, updatedAt=ended_at)
+
+    def get_session(self, session_id: int) -> SessionDTO:
+        return self._sessions[session_id]
+
+
+class FakeSessionEvidenceDAO:
+    """Store evidence DTOs without touching SQL Server."""
+
+    def __init__(self) -> None:
+        self._records: Dict[int, SessionEvidenceDTO] = {}
+        self._next_id = 1
+
+    def create_evidence(
+        self,
+        session_id: int,
+        file_name: str,
+        file_path: str,
+        description: str,
+        considerations: str,
+        observations: str,
+        created_at: datetime,
+        elapsed_since_start: int,
+        elapsed_since_previous: int | None,
+    ) -> SessionEvidenceDTO:
+        evidence_id = self._next_id
+        self._next_id += 1
+        dto = SessionEvidenceDTO(
+            evidenceId=evidence_id,
+            sessionId=session_id,
+            fileName=file_name,
+            filePath=file_path,
+            description=description,
+            considerations=considerations,
+            observations=observations,
+            createdAt=created_at,
+            updatedAt=created_at,
+            elapsedSinceSessionStartSeconds=elapsed_since_start,
+            elapsedSincePreviousEvidenceSeconds=elapsed_since_previous,
+        )
+        self._records[evidence_id] = dto
+        return dto
+
+    def update_evidence(
+        self,
+        evidence_id: int,
+        file_name: str,
+        file_path: str,
+        description: str,
+        considerations: str,
+        observations: str,
+        updated_at: datetime,
+    ) -> None:
+        dto = self._records[evidence_id]
+        self._records[evidence_id] = replace(
+            dto,
+            fileName=file_name,
+            filePath=file_path,
+            description=description,
+            considerations=considerations,
+            observations=observations,
+            updatedAt=updated_at,
+        )
+
+    def list_by_session(self, session_id: int) -> List[SessionEvidenceDTO]:
+        return [dto for dto in self._records.values() if dto.sessionId == session_id]
+
+
+class FakeSessionPauseDAO:
+    """Keep track of pauses in memory."""
+
+    def __init__(self) -> None:
+        self._records: Dict[int, SessionPauseDTO] = {}
+        self._next_id = 1
+
+    def create_pause(self, session_id: int, paused_at: datetime, elapsed_seconds_when_paused: int) -> SessionPauseDTO:
+        pause_id = self._next_id
+        self._next_id += 1
+        dto = SessionPauseDTO(
+            pauseId=pause_id,
+            sessionId=session_id,
+            pausedAt=paused_at,
+            resumedAt=None,
+            elapsedSecondsWhenPaused=elapsed_seconds_when_paused,
+            pauseDurationSeconds=None,
+        )
+        self._records[pause_id] = dto
+        return dto
+
+    def finish_pause(self, pause_id: int, resumed_at: datetime, pause_duration_seconds: int) -> None:
+        dto = self._records[pause_id]
+        self._records[pause_id] = replace(dto, resumedAt=resumed_at, pauseDurationSeconds=pause_duration_seconds)
+
+    def list_by_session(self, session_id: int) -> List[SessionPauseDTO]:
+        return [dto for dto in self._records.values() if dto.sessionId == session_id]
+
+
+class DeterministicSessionService(SessionService):
+    """Session service that advances one second on each `_utcnow` call."""
+
+    def __init__(
+        self,
+        session_dao: FakeSessionDAO,
+        evidence_dao: FakeSessionEvidenceDAO,
+        pause_dao: FakeSessionPauseDAO,
+        start_time: datetime,
+    ) -> None:
+        super().__init__(session_dao, evidence_dao, pause_dao)
+        self._current_time = start_time
+
+    def _utcnow(self) -> datetime:  # type: ignore[override]
+        current = self._current_time
+        self._current_time = current + timedelta(seconds=1)
+        return current
+
+
+def test_session_lifecycle_records_evidences_and_pauses() -> None:
+    """Sessions should register evidences, pauses and accumulate durations."""
+
+    start = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    service = DeterministicSessionService(FakeSessionDAO(), FakeSessionEvidenceDAO(), FakeSessionPauseDAO(), start)
+
+    session = service.begin_session("Demo", "http://example", "doc.docx", "evidences", "alice")
+    assert session.sessionId == 1
+    assert service.get_active_session() is not None
+
+    evidence1 = service.record_evidence(Path("shot1.png"), "Primer paso", "", "")
+    assert evidence1.elapsedSinceSessionStartSeconds == 2
+
+    pause = service.pause_session()
+    assert pause.elapsedSecondsWhenPaused == 3
+
+    service.resume_session()
+    evidence2 = service.record_evidence(Path("shot2.png"), "Segundo", "", "")
+    assert evidence2.elapsedSinceSessionStartSeconds == 5
+    assert evidence2.elapsedSincePreviousEvidenceSeconds == 4
+
+    evidences = service.list_evidences()
+    assert len(evidences) == 2
+
+    finished = service.finalize_session()
+    assert finished.durationSeconds == 7
+    assert service.get_active_session() is None
+
+
+def test_record_evidence_without_session_raises() -> None:
+    """Trying to capture without an active session should fail."""
+
+    service = DeterministicSessionService(FakeSessionDAO(), FakeSessionEvidenceDAO(), FakeSessionPauseDAO(), datetime.now(timezone.utc))
+    with pytest.raises(SessionServiceError):
+        service.record_evidence(Path("invalid.png"), "", "", "")


### PR DESCRIPTION
## Summary
- add session, evidence and pause data models with SQL Server DAOs and business service
- expose session lifecycle operations through the main controller and extend the GUI with timer, pause/resume and evidence editing controls
- document the new tables and cover the session workflow with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68f81a838728832cb816dae726339c55