### PR TITLE
Add session dashboard and management to tests view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
  - Los controles del tablero de sesiones mantienen un estilo caricaturesco y ahora exhiben botones de acciones con tipografía destacada en lugar de iconos.
 - La acción **Editar** abre la pestaña principal de evidencias reutilizando todas las herramientas (incluida la edición de capturas) en lugar de mostrar una ventana modal separada.
 - Las acciones dentro del tablero ahora se renderizan como botones azules al estilo de **Crear sesión**, conservando las restricciones para propietarios.
+- Los botones de acciones del tablero usan una variante compacta que mantiene el estilo azul sin dominar el contenido de cada fila.
 
 ### Fixed
 - Se impide editar o eliminar sesiones creadas por otros usuarios mostrando avisos claros en la tabla.
 - Se corrigió la alineación de la tabla del tablero de sesiones para que coincida con los encabezados y conserve el estilo azul.
+- Se reordenó el tablero para que la tabla permanezca debajo de los controles principales de creación y actualización.
 
 ## [0.6.1] - 2024-05-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 - Tablero inicial en la sección de pruebas con tabla moderna, acciones rápidas y botón para crear sesiones nuevas.
 - Acciones para ver, editar, eliminar y preparar la descarga de sesiones directamente desde la interfaz.
 - Métodos en `SessionDAO`, `SessionService` y `MainController` para listar, actualizar y eliminar sesiones existentes.
+- Editor integral de sesiones desde la vista de pruebas para actualizar metadatos y evidencias existentes.
 
 ### Changed
 - La vista de pruebas ahora organiza el flujo en pestañas y solo muestra los controles inferiores cuando corresponde.
+- Los botones del tablero de sesiones adoptan un estilo caricaturesco con iconografía distintiva para cada acción.
 
 ### Fixed
 - Se impide editar o eliminar sesiones creadas por otros usuarios mostrando avisos claros en la tabla.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@
 - Tablero inicial en la sección de pruebas con tabla moderna, acciones rápidas y botón para crear sesiones nuevas.
 - Acciones para ver, editar, eliminar y preparar la descarga de sesiones directamente desde la interfaz.
 - Métodos en `SessionDAO`, `SessionService` y `MainController` para listar, actualizar y eliminar sesiones existentes.
-- Editor integral de sesiones desde la vista de pruebas para actualizar metadatos y evidencias existentes.
+- Botón **Actualizar sesión** dentro de la pestaña de evidencias para guardar los metadatos cargados desde el tablero.
 
 ### Changed
 - La vista de pruebas ahora organiza el flujo en pestañas y solo muestra los controles inferiores cuando corresponde.
 - Los botones del tablero de sesiones adoptan un estilo caricaturesco con iconografía distintiva para cada acción.
+- La acción **Editar** abre la pestaña principal de evidencias reutilizando todas las herramientas (incluida la edición de capturas) en lugar de mostrar una ventana modal separada.
 
 ### Fixed
 - Se impide editar o eliminar sesiones creadas por otros usuarios mostrando avisos claros en la tabla.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.7.0] - 2024-05-31
+### Added
+- Tablero inicial en la sección de pruebas con tabla moderna, acciones rápidas y botón para crear sesiones nuevas.
+- Acciones para ver, editar, eliminar y preparar la descarga de sesiones directamente desde la interfaz.
+- Métodos en `SessionDAO`, `SessionService` y `MainController` para listar, actualizar y eliminar sesiones existentes.
+
+### Changed
+- La vista de pruebas ahora organiza el flujo en pestañas y solo muestra los controles inferiores cuando corresponde.
+
+### Fixed
+- Se impide editar o eliminar sesiones creadas por otros usuarios mostrando avisos claros en la tabla.
+
 ## [0.6.1] - 2024-05-30
 ### Added
 - Vistas independientes para generación automática, generación manual y pruebas con sus componentes encapsulados dentro de `app/views`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 - Se impide editar o eliminar sesiones creadas por otros usuarios mostrando avisos claros en la tabla.
+- Se corrigió la alineación de la tabla del tablero de sesiones para que coincida con los encabezados y conserve el estilo azul.
 
 ## [0.6.1] - 2024-05-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@
 
 ### Changed
 - La vista de pruebas ahora organiza el flujo en pestañas y solo muestra los controles inferiores cuando corresponde.
-- Los botones del tablero de sesiones mantienen un estilo caricaturesco y las acciones se muestran como etiquetas tipo botón con texto destacado en lugar de iconos.
+ - Los controles del tablero de sesiones mantienen un estilo caricaturesco y ahora exhiben botones de acciones con tipografía destacada en lugar de iconos.
 - La acción **Editar** abre la pestaña principal de evidencias reutilizando todas las herramientas (incluida la edición de capturas) en lugar de mostrar una ventana modal separada.
+- Las acciones dentro del tablero ahora se renderizan como botones azules al estilo de **Crear sesión**, conservando las restricciones para propietarios.
 
 ### Fixed
 - Se impide editar o eliminar sesiones creadas por otros usuarios mostrando avisos claros en la tabla.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 - La vista de pruebas ahora organiza el flujo en pestañas y solo muestra los controles inferiores cuando corresponde.
-- Los botones del tablero de sesiones adoptan un estilo caricaturesco con iconografía distintiva para cada acción.
+- Los botones del tablero de sesiones mantienen un estilo caricaturesco y las acciones se muestran como etiquetas tipo botón con texto destacado en lugar de iconos.
 - La acción **Editar** abre la pestaña principal de evidencias reutilizando todas las herramientas (incluida la edición de capturas) en lugar de mostrar una ventana modal separada.
 
 ### Fixed

--- a/app/controllers/main_controller.py
+++ b/app/controllers/main_controller.py
@@ -82,6 +82,13 @@ class MainController:
         """Return the cached authenticated user, if any."""
         return self._authenticated_user
 
+    def get_authenticated_username(self) -> str:
+        """Return the username for the authenticated user or an empty string."""
+
+        if not self._authenticated_user or not self._authenticated_user.username:
+            return ""
+        return self._authenticated_user.username
+
     def getSessionsDirectory(self) -> Path:
         """Provide the storage folder for generated session documents."""
 
@@ -179,6 +186,49 @@ class MainController:
         except SessionServiceError as exc:
             return [], str(exc)
         return evidences, None
+
+    def list_sessions(self, limit: int = 100) -> Tuple[List[SessionDTO], Optional[str]]:
+        """Return the available sessions for the dashboard."""
+
+        try:
+            sessions = self._session_service.list_sessions(limit=limit)
+        except SessionServiceError as exc:
+            return [], str(exc)
+        return sessions, None
+
+    def update_session_details(
+        self,
+        session_id: int,
+        name: str,
+        initial_url: str,
+        docx_url: str,
+        evidences_url: str,
+    ) -> Optional[str]:
+        """Persist metadata changes requested from the dashboard."""
+
+        username = self.get_authenticated_username()
+        try:
+            self._session_service.update_session_details(
+                session_id,
+                name,
+                initial_url,
+                docx_url,
+                evidences_url,
+                username,
+            )
+        except SessionServiceError as exc:
+            return str(exc)
+        return None
+
+    def delete_session(self, session_id: int) -> Optional[str]:
+        """Remove a session when requested from the dashboard."""
+
+        username = self.get_authenticated_username()
+        try:
+            self._session_service.delete_session(session_id, username)
+        except SessionServiceError as exc:
+            return str(exc)
+        return None
 
     def update_session_evidence(
         self,

--- a/app/controllers/main_controller.py
+++ b/app/controllers/main_controller.py
@@ -230,6 +230,19 @@ class MainController:
             return str(exc)
         return None
 
+    def load_session_for_edit(
+        self,
+        session_id: int,
+    ) -> Tuple[Optional[SessionDTO], List[SessionEvidenceDTO], Optional[str]]:
+        """Return a session and its evidences for dashboard editing."""
+
+        username = self.get_authenticated_username()
+        try:
+            session, evidences = self._session_service.get_session_with_evidences(session_id, username)
+        except SessionServiceError as exc:
+            return None, [], str(exc)
+        return session, evidences, None
+
     def update_session_evidence(
         self,
         evidence_id: int,
@@ -242,6 +255,32 @@ class MainController:
 
         try:
             self._session_service.update_evidence(evidence_id, file_path, description, considerations, observations)
+        except SessionServiceError as exc:
+            return str(exc)
+        return None
+
+    def update_session_evidence_from_dashboard(
+        self,
+        session_id: int,
+        evidence_id: int,
+        file_path: Path,
+        description: str,
+        considerations: str,
+        observations: str,
+    ) -> Optional[str]:
+        """Persist evidence edits performed from the session dashboard."""
+
+        username = self.get_authenticated_username()
+        try:
+            self._session_service.update_session_evidence_details(
+                session_id,
+                evidence_id,
+                file_path,
+                description,
+                considerations,
+                observations,
+                username,
+            )
         except SessionServiceError as exc:
             return str(exc)
         return None

--- a/app/controllers/main_controller.py
+++ b/app/controllers/main_controller.py
@@ -243,6 +243,24 @@ class MainController:
             return None, [], str(exc)
         return session, evidences, None
 
+    def activate_session_for_dashboard_edit(
+        self,
+        session_id: int,
+    ) -> Tuple[Optional[SessionDTO], List[SessionEvidenceDTO], Optional[str]]:
+        """Load a session and mark it as active so the GUI can edit it."""
+
+        username = self.get_authenticated_username()
+        try:
+            session, evidences = self._session_service.activate_session_for_dashboard_edit(session_id, username)
+        except SessionServiceError as exc:
+            return None, [], str(exc)
+        return session, evidences, None
+
+    def clear_active_session(self) -> None:
+        """Release any active session cached in the service."""
+
+        self._session_service.clear_active_session()
+
     def update_session_evidence(
         self,
         evidence_id: int,

--- a/app/views/pruebas_view.py
+++ b/app/views/pruebas_view.py
@@ -246,6 +246,7 @@ def build_pruebas_view(
     sessions_canvas.configure(yscrollcommand=sessions_scroll.set)
 
     sessions_rows_holder = tk.Frame(sessions_canvas, bg=row_even_bg)
+    sessions_rows_holder.grid_columnconfigure(0, weight=1)
     sessions_window = sessions_canvas.create_window((0, 0), window=sessions_rows_holder, anchor="nw")
 
     def _on_sessions_canvas_configure(event) -> None:
@@ -335,7 +336,7 @@ def build_pruebas_view(
             is_owner = session_obj.username.lower() == current_username and bool(current_username)
             row_bg = row_even_bg if index % 2 == 0 else row_odd_bg
             row_frame = tk.Frame(sessions_rows_holder, bg=row_bg)
-            row_frame.grid(row=index - 1, column=0, sticky="ew", pady=(0, 8))
+            row_frame.grid(row=index - 1, column=0, sticky="ew", pady=(0, 8), padx=(0, 12))
             row_frame.grid_columnconfigure(0, minsize=160)
             row_frame.grid_columnconfigure(1, weight=1, minsize=240)
             row_frame.grid_columnconfigure(2, minsize=160)

--- a/app/views/pruebas_view.py
+++ b/app/views/pruebas_view.py
@@ -187,6 +187,23 @@ def build_pruebas_view(
         foreground=[("disabled", "#E9E7FF")],
     )
     style.configure(
+        "CartoonAccentSlim.TButton",
+        font=("Segoe UI", 10, "bold"),
+        foreground="#ffffff",
+        background="#6C63FF",
+        padding=(12, 6),
+        borderwidth=0,
+    )
+    style.map(
+        "CartoonAccentSlim.TButton",
+        background=[
+            ("active", "#867DFF"),
+            ("pressed", "#5548d9"),
+            ("disabled", "#B8B3FF"),
+        ],
+        foreground=[("disabled", "#E9E7FF")],
+    )
+    style.configure(
         "CartoonGhost.TButton",
         font=("Segoe UI", 11, "bold"),
         foreground="#414561",
@@ -205,6 +222,56 @@ def build_pruebas_view(
     header_bg = "#E8ECFF"
     row_even_bg = "#ffffff"
     row_odd_bg = "#f5f7fa"
+
+    dashboard_header = tb.Frame(dashboard_tab)
+    dashboard_header.pack(fill=X, pady=(0, 16))
+    tb.Label(
+        dashboard_header,
+        text="Sesiones de pruebas",
+        font=("Segoe UI", 16, "bold"),
+    ).pack(side=LEFT)
+
+    def _get_current_username() -> str:
+        """Return the username of the authenticated operator."""
+
+        return controller.get_authenticated_username().strip()
+
+    def _prepare_new_session_form() -> None:
+        """Reset the inputs before creating a new session."""
+
+        try:
+            base_var.set("reporte")
+        except Exception:
+            pass
+        default_url = controller.DEFAULT_URL
+        urls = controller.load_history(controller.URL_HISTORY_CATEGORY, default_url)
+        try:
+            url_var.set(urls[0] if urls else default_url)
+        except Exception:
+            pass
+        refresh_paths()
+        status.set("🆕 Prepara una nueva sesión de evidencias.")
+
+    def _open_new_session_tab() -> None:
+        """Navigate to the evidence tab to start a new session."""
+
+        _prepare_new_session_form()
+        notebook.select(session_tab)
+
+    tb.Button(
+        dashboard_header,
+        text="🔄 Actualizar",
+        style="CartoonGhost.TButton",
+        command=lambda: _refresh_sessions_table(),
+        compound=LEFT,
+    ).pack(side=RIGHT)
+    tb.Button(
+        dashboard_header,
+        text="✨ Crear sesión",
+        style="CartoonAccent.TButton",
+        command=_open_new_session_tab,
+        compound=LEFT,
+    ).pack(side=RIGHT, padx=(0, 8))
 
     table_container = tb.Frame(dashboard_tab)
     table_container.pack(fill=BOTH, expand=YES)
@@ -269,56 +336,6 @@ def build_pruebas_view(
     sessions_rows_holder.bind("<Configure>", _update_sessions_scrollregion, add="+")
     bind_mousewheel(sessions_canvas, sessions_canvas.yview)
 
-    dashboard_header = tb.Frame(dashboard_tab)
-    dashboard_header.pack(fill=X, pady=(0, 16))
-    tb.Label(
-        dashboard_header,
-        text="Sesiones de pruebas",
-        font=("Segoe UI", 16, "bold"),
-    ).pack(side=LEFT)
-
-    def _get_current_username() -> str:
-        """Return the username of the authenticated operator."""
-
-        return controller.get_authenticated_username().strip()
-
-    def _prepare_new_session_form() -> None:
-        """Reset the inputs before creating a new session."""
-
-        try:
-            base_var.set("reporte")
-        except Exception:
-            pass
-        default_url = controller.DEFAULT_URL
-        urls = controller.load_history(controller.URL_HISTORY_CATEGORY, default_url)
-        try:
-            url_var.set(urls[0] if urls else default_url)
-        except Exception:
-            pass
-        refresh_paths()
-        status.set("🆕 Prepara una nueva sesión de evidencias.")
-
-    def _open_new_session_tab() -> None:
-        """Navigate to the evidence tab to start a new session."""
-
-        _prepare_new_session_form()
-        notebook.select(session_tab)
-
-    tb.Button(
-        dashboard_header,
-        text="🔄 Actualizar",
-        style="CartoonGhost.TButton",
-        command=lambda: _refresh_sessions_table(),
-        compound=LEFT,
-    ).pack(side=RIGHT)
-    tb.Button(
-        dashboard_header,
-        text="✨ Crear sesión",
-        style="CartoonAccent.TButton",
-        command=_open_new_session_tab,
-        compound=LEFT,
-    ).pack(side=RIGHT, padx=(0, 8))
-
     def _refresh_sessions_table() -> None:
         """Reload the table with the latest sessions from the service."""
 
@@ -378,9 +395,9 @@ def build_pruebas_view(
                 btn = tb.Button(
                     actions_frame,
                     text=label,
-                    style="CartoonAccent.TButton",
+                    style="CartoonAccentSlim.TButton",
                     command=handler,
-                    width=12,
+                    width=9,
                 )
                 if not enabled:
                     btn.configure(state="disabled")

--- a/app/views/pruebas_view.py
+++ b/app/views/pruebas_view.py
@@ -250,7 +250,22 @@ def build_pruebas_view(
     ).pack(side=RIGHT, padx=(0, 8))
 
     action_labels = ("Ver", "Editar", "Eliminar", "Descargar")
-    action_icons = ("🔍", "🎨", "🗑️", "⬇️")
+    action_wrappers = (
+        ("╭", "╮"),
+        ("╔", "╗"),
+        ("╠", "╣"),
+        ("╚", "╝"),
+    )
+
+    def _make_action_badge(label: str, wrappers: tuple[str, str]) -> str:
+        """Render a badge-like string to emulate buttons within the table."""
+
+        edge_left, edge_right = wrappers
+        clean_label = label.upper()
+        filler_width = max(1, 6 - len(clean_label) // 2)
+        filler = "═" * filler_width
+        return f"{edge_left}{filler} {clean_label} {filler}{edge_right}"
+
     sessions_tree = ttk.Treeview(
         dashboard_tab,
         columns=("fecha", "nombre", "usuario", "acciones"),
@@ -293,12 +308,10 @@ def build_pruebas_view(
             is_owner = session_obj.username.lower() == current_username and bool(current_username)
             row_labels = []
             for action_index, base_label in enumerate(action_labels):
-                icon = action_icons[action_index]
                 label_text = base_label
                 if action_index in (1, 2) and not is_owner:
-                    icon = "🔒"
                     label_text = f"{base_label} (solo propietario)"
-                row_labels.append(f"{icon} {label_text}")
+                row_labels.append(_make_action_badge(label_text, action_wrappers[action_index]))
             sessions_tree.insert(
                 "",
                 "end",


### PR DESCRIPTION
## Summary
- add a sessions dashboard tab to the pruebas view with a styled table and quick actions
- implement controller, service, and DAO capabilities to list, update, and delete sessions while enforcing ownership rules
- update the changelog to record the new dashboard feature and ownership safeguards

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f95142628c832cbc4c336088c46b8d