### PR TITLE
feat: add AI-assisted DDE/HU generator view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - `MainController` inicializa el nuevo controlador de tarjetas y lo expone a la interfaz para consumir el LLM a través del backend.
 - `main_view.py` incorpora la vista de generación DDE/HU en el menú principal y la navegación lateral.
 
+### Fixed
+- Corrección en los callbacks asíncronos de la vista **Generar DDE/HU** para mantener el mensaje de error disponible al mostrar cuadros de diálogo y evitar excepciones `NameError`.
+
 ## [0.7.1] - 2024-06-01
 ### Added
 - Controladores especializados para autenticación, historial, navegador, nomenclatura y sesiones que encapsulan la coordinación con sus servicios correspondientes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.8.0] - 2024-06-02
+### Added
+- Vista **Generar DDE/HU** con listado de tarjetas, captura de análisis y recomendación, historial de ejecuciones y exportación de resultados JSON desde `app/views/generar_dde_hu_view.py`.
+- Controlador, servicio, DAOs y DTOs dedicados para coordinar la generación con LLM local incluyendo cálculo de completitud, guardado de borradores y regeneración (`app/controllers/cards_controller.py`, `app/services/card_ai_service.py`, `app/daos/cards_dao.py`, `app/dtos/card_ai_dto.py`, `app/services/llm_client.py`, `app/services/card_prompt_builder.py`).
+- Pruebas unitarias que validan el flujo principal del servicio de tarjetas simulando LLM y persistencia (`tests/test_card_ai_service.py`).
+- Tablas `dbo.cards_ai_inputs` y `dbo.cards_ai_outputs` documentadas en `docs/database_schema.md` para conservar los datos capturados y los resultados generados por IA.
+
+### Changed
+- `MainController` inicializa el nuevo controlador de tarjetas y lo expone a la interfaz para consumir el LLM a través del backend.
+- `main_view.py` incorpora la vista de generación DDE/HU en el menú principal y la navegación lateral.
+
 ## [0.7.1] - 2024-06-01
 ### Added
 - Controladores especializados para autenticación, historial, navegador, nomenclatura y sesiones que encapsulan la coordinación con sus servicios correspondientes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Corrección en los callbacks asíncronos de la vista **Generar DDE/HU** para mantener el mensaje de error disponible al mostrar cuadros de diálogo y evitar excepciones `NameError`.
+- Ajuste en el DAO de resultados de IA para que la tabla `cards_ai_outputs` se prepare aun cuando `cards_ai_inputs` no exista todavía, evitando el error al abrir el historial desde una tarjeta sin ejecuciones previas.
 
 ## [0.7.1] - 2024-06-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 - Corrección en los callbacks asíncronos de la vista **Generar DDE/HU** para mantener el mensaje de error disponible al mostrar cuadros de diálogo y evitar excepciones `NameError`.
 - Ajuste en el DAO de resultados de IA para que la tabla `cards_ai_outputs` se prepare aun cuando `cards_ai_inputs` no exista todavía, evitando el error al abrir el historial desde una tarjeta sin ejecuciones previas.
+- La recarga de tarjetas ahora toma los valores de los filtros antes de lanzar el hilo en segundo plano, eliminando el `RuntimeError: main thread is not in main loop` al seleccionar una tarjeta.
 
 ## [0.7.1] - 2024-06-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Corrección en los callbacks asíncronos de la vista **Generar DDE/HU** para mantener el mensaje de error disponible al mostrar cuadros de diálogo y evitar excepciones `NameError`.
 - Ajuste en el DAO de resultados de IA para que la tabla `cards_ai_outputs` se prepare aun cuando `cards_ai_inputs` no exista todavía, evitando el error al abrir el historial desde una tarjeta sin ejecuciones previas.
 - La recarga de tarjetas ahora toma los valores de los filtros antes de lanzar el hilo en segundo plano, eliminando el `RuntimeError: main thread is not in main loop` al seleccionar una tarjeta.
+- La vista **Generar DDE/HU** procesa las respuestas en una cola del hilo principal y elimina el `RuntimeError: main thread is not in main loop` que aparecía al iniciar la aplicación.
 
 ## [0.7.1] - 2024-06-01
 ### Added

--- a/app/controllers/cards_controller.py
+++ b/app/controllers/cards_controller.py
@@ -1,0 +1,84 @@
+"""Controller dedicated to the card-based AI generation flow."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from app.dtos.card_ai_dto import (
+    CardAIInputPayload,
+    CardAIInputRecord,
+    CardAIOutputRecord,
+    CardFilters,
+    CardSummary,
+    GenerationResult,
+)
+from app.services.card_ai_service import CardAIService, CardAIServiceError
+
+
+class CardsControllerError(RuntimeError):
+    """Raised when the controller cannot complete the requested action."""
+
+
+class CardsController:
+    """Expose high-level operations required by the AI generation view."""
+
+    def __init__(self, service: CardAIService) -> None:
+        """Persist the service dependency used by the controller."""
+
+        self._service = service
+
+    def listCards(self, filters: Optional[CardFilters] = None) -> List[CardSummary]:
+        """Return cards according to the provided filters."""
+
+        try:
+            return self._service.listCards(filters)
+        except CardAIServiceError as exc:
+            raise CardsControllerError(str(exc)) from exc
+
+    def calculateCompleteness(self, payload: CardAIInputPayload) -> int:
+        """Delegate the completeness calculation to the service."""
+
+        return self._service.calculateCompleteness(payload)
+
+    def loadLatestInput(self, card_id: int) -> Optional[CardAIInputRecord]:
+        """Load the most recent saved input for the specified card."""
+
+        try:
+            return self._service.loadLatestInput(card_id)
+        except CardAIServiceError as exc:
+            raise CardsControllerError(str(exc)) from exc
+
+    def saveDraft(self, payload: CardAIInputPayload) -> CardAIInputRecord:
+        """Persist the captured inputs without calling the LLM."""
+
+        try:
+            return self._service.saveDraft(payload)
+        except CardAIServiceError as exc:
+            raise CardsControllerError(str(exc)) from exc
+
+    def generateDocument(self, payload: CardAIInputPayload) -> GenerationResult:
+        """Trigger the LLM using the provided payload."""
+
+        try:
+            return self._service.generateDocument(payload)
+        except CardAIServiceError as exc:
+            raise CardsControllerError(str(exc)) from exc
+
+    def regenerateFromInput(self, input_id: int) -> GenerationResult:
+        """Re-run the LLM using a previously stored input."""
+
+        try:
+            return self._service.regenerateFromInput(input_id)
+        except CardAIServiceError as exc:
+            raise CardsControllerError(str(exc)) from exc
+
+    def listOutputs(self, card_id: int) -> List[CardAIOutputRecord]:
+        """Return the history of LLM generations for a card."""
+
+        try:
+            return self._service.listOutputs(card_id)
+        except CardAIServiceError as exc:
+            raise CardsControllerError(str(exc)) from exc
+
+
+__all__ = ["CardsController", "CardsControllerError"]

--- a/app/controllers/main_controller.py
+++ b/app/controllers/main_controller.py
@@ -9,20 +9,24 @@ from app.config.storage_paths import (
 )
 from app.controllers.auth_controller import AuthenticationController
 from app.controllers.browser_controller import BrowserController
+from app.controllers.cards_controller import CardsController
 from app.controllers.history_controller import HistoryController
 from app.controllers.naming_controller import NamingController
 from app.controllers.session_controller import SessionController
 from app.daos.database import DatabaseConnector
+from app.daos.cards_dao import CardAIInputDAO, CardAIOutputDAO, CardsDAO
 from app.daos.evidence_dao import SessionEvidenceDAO
 from app.daos.history_dao import HistoryDAO
 from app.daos.session_dao import SessionDAO
 from app.daos.session_pause_dao import SessionPauseDAO
 from app.daos.user_dao import UserDAO
 from app.services.auth_service import AuthService
+from app.services.card_ai_service import CardAIService
 from app.services.browser_service import BrowserService
 from app.services.history_service import HistoryService
 from app.services.naming_service import NamingService
 from app.services.session_service import SessionService
+from app.services.llm_client import LocalLLMClient
 
 
 class MainController:
@@ -67,3 +71,12 @@ class MainController:
             self.SESSIONS_DIR,
             self.EVIDENCE_DIR,
         )
+
+        cards_connector = DatabaseConnector().connection_factory()
+        card_ai_service = CardAIService(
+            CardsDAO(cards_connector),
+            CardAIInputDAO(cards_connector),
+            CardAIOutputDAO(cards_connector),
+            LocalLLMClient(),
+        )
+        self.cards = CardsController(card_ai_service)

--- a/app/daos/cards_dao.py
+++ b/app/daos/cards_dao.py
@@ -1,0 +1,599 @@
+"""Data access helpers for cards and AI generation records."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Callable, List, Optional, Sequence
+
+from app.daos.database import DatabaseConnectorError
+from app.dtos.card_ai_dto import (
+    CardAIInputRecord,
+    CardAIOutputRecord,
+    CardFilters,
+    CardSummary,
+)
+
+
+class CardsDAOError(RuntimeError):
+    """Raised when the card catalog cannot be queried."""
+
+
+class CardAIInputDAOError(RuntimeError):
+    """Raised when persisting captured inputs fails."""
+
+
+class CardAIOutputDAOError(RuntimeError):
+    """Raised when storing LLM outputs fails."""
+
+
+def _normalize_datetime(value: object) -> Optional[datetime]:
+    """Normalize SQL Server values into timezone-aware datetimes."""
+
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+    try:
+        seconds = int(value)
+    except (TypeError, ValueError):
+        return None
+    return datetime.fromtimestamp(seconds, tz=timezone.utc)
+
+
+def _clean_string(value: Optional[str]) -> str:
+    """Return a trimmed string representation for SQL persistence."""
+
+    return (value or "").strip()
+
+
+class CardsDAO:
+    """Provide read operations for the dbo.cards table."""
+
+    def __init__(self, connection_factory: Callable[[], "pymssql.Connection"]) -> None:
+        """Store the callable that creates SQL Server connections."""
+
+        self._connection_factory = connection_factory
+
+    def listCards(self, filters: Optional[CardFilters] = None, limit: int = 250) -> List[CardSummary]:
+        """Return a limited set of cards applying optional filters."""
+
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardsDAOError(str(exc)) from exc
+
+        query = [
+            "SELECT TOP (%s) c.id, c.title, COALESCE(it.name, '') AS tipo, c.status, c.created_at "
+            "FROM dbo.cards c "
+            "LEFT JOIN dbo.catalog_incidence_types it ON it.id = c.incidence_type_id "
+        ]
+        params: List[object] = [limit]
+        conditions: List[str] = []
+
+        if filters:
+            if filters.tipo:
+                conditions.append("(LOWER(it.name) = LOWER(%s) OR LOWER(c.status) = LOWER(%s))")
+                params.extend([filters.tipo, filters.tipo])
+            if filters.status:
+                conditions.append("LOWER(c.status) = LOWER(%s)")
+                params.append(filters.status)
+
+        if conditions:
+            query.append("WHERE " + " AND ".join(conditions))
+
+        query.append("ORDER BY c.created_at DESC, c.id DESC")
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(" ".join(query), tuple(params))
+            rows: Sequence[Sequence[object]] = cursor.fetchall() or []
+        except Exception as exc:  # pragma: no cover - depende del driver
+            connection.close()
+            raise CardsDAOError("No fue posible leer las tarjetas desde la base de datos.") from exc
+
+        cards: List[CardSummary] = []
+        for row in rows:
+            card_id = int(row[0]) if row and row[0] is not None else 0
+            title = str(row[1]) if len(row) > 1 and row[1] is not None else ""
+            tipo = str(row[2]) if len(row) > 2 and row[2] is not None else ""
+            status = str(row[3]) if len(row) > 3 and row[3] is not None else ""
+            created_at = _normalize_datetime(row[4] if len(row) > 4 else None)
+            cards.append(CardSummary(card_id, title, tipo, status, created_at))
+
+        connection.close()
+        return cards
+
+    def fetchCard(self, card_id: int) -> Optional[CardSummary]:
+        """Retrieve a single card by identifier."""
+
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardsDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "SELECT c.id, c.title, COALESCE(it.name, '') AS tipo, c.status, c.created_at "
+                    "FROM dbo.cards c "
+                    "LEFT JOIN dbo.catalog_incidence_types it ON it.id = c.incidence_type_id "
+                    "WHERE c.id = %s"
+                ),
+                (card_id,),
+            )
+            row = cursor.fetchone()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            connection.close()
+            raise CardsDAOError("No fue posible consultar la tarjeta solicitada.") from exc
+
+        connection.close()
+        if not row:
+            return None
+        card_id_value = int(row[0]) if row[0] is not None else card_id
+        title = str(row[1]) if row[1] is not None else ""
+        tipo = str(row[2]) if row[2] is not None else ""
+        status = str(row[3]) if row[3] is not None else ""
+        created_at = _normalize_datetime(row[4])
+        return CardSummary(card_id_value, title, tipo, status, created_at)
+
+
+class CardAIInputDAO:
+    """Persist captured inputs that feed the LLM generation."""
+
+    def __init__(self, connection_factory: Callable[[], "pymssql.Connection"]) -> None:
+        """Store the connection factory and lazily ensure the schema."""
+
+        self._connection_factory = connection_factory
+        self._schema_ready = False
+
+    def _ensure_schema(self) -> None:
+        """Create the inputs table when it does not exist."""
+
+        if self._schema_ready:
+            return
+
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardAIInputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.tables t
+                    INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+                    WHERE t.name = 'cards_ai_inputs' AND s.name = 'dbo'
+                )
+                BEGIN
+                    CREATE TABLE dbo.cards_ai_inputs (
+                        input_id BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+                        card_id BIGINT NOT NULL,
+                        tipo VARCHAR(20) NOT NULL,
+                        analisis_desc_problema NVARCHAR(MAX) NULL,
+                        analisis_revision_sistema NVARCHAR(MAX) NULL,
+                        analisis_datos NVARCHAR(MAX) NULL,
+                        analisis_comp_reglas NVARCHAR(MAX) NULL,
+                        reco_investigacion NVARCHAR(MAX) NULL,
+                        reco_solucion_temporal NVARCHAR(MAX) NULL,
+                        reco_impl_mejoras NVARCHAR(MAX) NULL,
+                        reco_com_stakeholders NVARCHAR(MAX) NULL,
+                        reco_documentacion NVARCHAR(MAX) NULL,
+                        completeness_pct TINYINT NOT NULL DEFAULT(0),
+                        is_draft BIT NOT NULL DEFAULT(1),
+                        created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+                        updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME()
+                    );
+                    CREATE INDEX ix_cards_ai_inputs_card_id
+                        ON dbo.cards_ai_inputs (card_id, updated_at DESC, input_id DESC);
+                END
+                """
+            )
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.foreign_keys WHERE name = 'fk_cards_ai_inputs_card'
+                )
+                BEGIN
+                    ALTER TABLE dbo.cards_ai_inputs
+                        ADD CONSTRAINT fk_cards_ai_inputs_card
+                        FOREIGN KEY (card_id) REFERENCES dbo.cards(id);
+                END
+                """
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise CardAIInputDAOError("No fue posible preparar la tabla de entradas para IA.") from exc
+
+        connection.close()
+        self._schema_ready = True
+
+    def insertInput(self, record: CardAIInputRecord) -> int:
+        """Persist a new captured input and return its identifier."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardAIInputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                INSERT INTO dbo.cards_ai_inputs (
+                    card_id, tipo, analisis_desc_problema, analisis_revision_sistema,
+                    analisis_datos, analisis_comp_reglas, reco_investigacion,
+                    reco_solucion_temporal, reco_impl_mejoras, reco_com_stakeholders,
+                    reco_documentacion, completeness_pct, is_draft, created_at, updated_at
+                )
+                OUTPUT INSERTED.input_id
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, SYSUTCDATETIME(), SYSUTCDATETIME())
+                """,
+                (
+                    record.cardId,
+                    record.tipo,
+                    _clean_string(record.analisisDescProblema),
+                    _clean_string(record.analisisRevisionSistema),
+                    _clean_string(record.analisisDatos),
+                    _clean_string(record.analisisCompReglas),
+                    _clean_string(record.recoInvestigacion),
+                    _clean_string(record.recoSolucionTemporal),
+                    _clean_string(record.recoImplMejoras),
+                    _clean_string(record.recoComStakeholders),
+                    _clean_string(record.recoDocumentacion),
+                    record.completenessPct,
+                    1 if record.isDraft else 0,
+                ),
+            )
+            row = cursor.fetchone()
+            input_id = int(row[0]) if row else 0
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise CardAIInputDAOError("No fue posible guardar los datos capturados para la tarjeta.") from exc
+
+        connection.close()
+        return input_id
+
+    def updateDraftFlag(self, input_id: int, is_draft: bool) -> None:
+        """Adjust the draft flag on an existing input."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardAIInputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                UPDATE dbo.cards_ai_inputs
+                SET is_draft = %s, updated_at = SYSUTCDATETIME()
+                WHERE input_id = %s
+                """,
+                (1 if is_draft else 0, input_id),
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise CardAIInputDAOError("No fue posible actualizar el estado del borrador.") from exc
+
+        connection.close()
+
+    def fetchLatestForCard(self, card_id: int) -> Optional[CardAIInputRecord]:
+        """Return the most recent input captured for the given card."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardAIInputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "SELECT TOP (1) input_id, card_id, tipo, analisis_desc_problema, analisis_revision_sistema,"
+                    " analisis_datos, analisis_comp_reglas, reco_investigacion, reco_solucion_temporal,"
+                    " reco_impl_mejoras, reco_com_stakeholders, reco_documentacion, completeness_pct, is_draft,"
+                    " created_at, updated_at"
+                    " FROM dbo.cards_ai_inputs WHERE card_id = %s"
+                    " ORDER BY updated_at DESC, input_id DESC"
+                ),
+                (card_id,),
+            )
+            row = cursor.fetchone()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            connection.close()
+            raise CardAIInputDAOError("No fue posible obtener el último borrador registrado.") from exc
+
+        connection.close()
+        if not row:
+            return None
+        return self._row_to_record(row)
+
+    def fetchById(self, input_id: int) -> Optional[CardAIInputRecord]:
+        """Retrieve a specific input by identifier."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardAIInputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "SELECT input_id, card_id, tipo, analisis_desc_problema, analisis_revision_sistema,"
+                    " analisis_datos, analisis_comp_reglas, reco_investigacion, reco_solucion_temporal,"
+                    " reco_impl_mejoras, reco_com_stakeholders, reco_documentacion, completeness_pct, is_draft,"
+                    " created_at, updated_at"
+                    " FROM dbo.cards_ai_inputs WHERE input_id = %s"
+                ),
+                (input_id,),
+            )
+            row = cursor.fetchone()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            connection.close()
+            raise CardAIInputDAOError("No fue posible consultar los datos guardados para la tarjeta.") from exc
+
+        connection.close()
+        if not row:
+            return None
+        return self._row_to_record(row)
+
+    def _row_to_record(self, row: Sequence[object]) -> CardAIInputRecord:
+        """Convert a SQL row into a ``CardAIInputRecord`` instance."""
+
+        return CardAIInputRecord(
+            inputId=int(row[0]) if row[0] is not None else None,
+            cardId=int(row[1]) if row[1] is not None else 0,
+            tipo=str(row[2]) if row[2] is not None else "",
+            analisisDescProblema=str(row[3]) if row[3] is not None else None,
+            analisisRevisionSistema=str(row[4]) if row[4] is not None else None,
+            analisisDatos=str(row[5]) if row[5] is not None else None,
+            analisisCompReglas=str(row[6]) if row[6] is not None else None,
+            recoInvestigacion=str(row[7]) if row[7] is not None else None,
+            recoSolucionTemporal=str(row[8]) if row[8] is not None else None,
+            recoImplMejoras=str(row[9]) if row[9] is not None else None,
+            recoComStakeholders=str(row[10]) if row[10] is not None else None,
+            recoDocumentacion=str(row[11]) if row[11] is not None else None,
+            completenessPct=int(row[12]) if row[12] is not None else 0,
+            isDraft=bool(row[13]) if row[13] is not None else True,
+            createdAt=_normalize_datetime(row[14] if len(row) > 14 else None),
+            updatedAt=_normalize_datetime(row[15] if len(row) > 15 else None),
+        )
+
+
+class CardAIOutputDAO:
+    """Persist the JSON responses produced by the LLM."""
+
+    def __init__(self, connection_factory: Callable[[], "pymssql.Connection"]) -> None:
+        """Store the connection factory used to communicate with SQL Server."""
+
+        self._connection_factory = connection_factory
+        self._schema_ready = False
+
+    def _ensure_schema(self) -> None:
+        """Create the outputs table and constraints when required."""
+
+        if self._schema_ready:
+            return
+
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardAIOutputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.tables t
+                    INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+                    WHERE t.name = 'cards_ai_outputs' AND s.name = 'dbo'
+                )
+                BEGIN
+                    CREATE TABLE dbo.cards_ai_outputs (
+                        output_id BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+                        card_id BIGINT NOT NULL,
+                        input_id BIGINT NULL,
+                        llm_id VARCHAR(100) NULL,
+                        llm_model VARCHAR(100) NULL,
+                        llm_usage_json NVARCHAR(MAX) NULL,
+                        content_json NVARCHAR(MAX) NOT NULL,
+                        created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME()
+                    );
+                    CREATE INDEX ix_cards_ai_outputs_card_id
+                        ON dbo.cards_ai_outputs (card_id, created_at DESC, output_id DESC);
+                END
+                """
+            )
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.foreign_keys WHERE name = 'fk_cards_ai_outputs_card'
+                )
+                BEGIN
+                    ALTER TABLE dbo.cards_ai_outputs
+                        ADD CONSTRAINT fk_cards_ai_outputs_card
+                        FOREIGN KEY (card_id) REFERENCES dbo.cards(id);
+                END
+                """
+            )
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.foreign_keys WHERE name = 'fk_cards_ai_outputs_input'
+                )
+                BEGIN
+                    ALTER TABLE dbo.cards_ai_outputs
+                        ADD CONSTRAINT fk_cards_ai_outputs_input
+                        FOREIGN KEY (input_id) REFERENCES dbo.cards_ai_inputs(input_id);
+                END
+                """
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise CardAIOutputDAOError("No fue posible preparar la tabla de resultados de IA.") from exc
+
+        connection.close()
+        self._schema_ready = True
+
+    def insertOutput(self, record: CardAIOutputRecord) -> int:
+        """Persist a new LLM response and return its identifier."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardAIOutputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                INSERT INTO dbo.cards_ai_outputs (
+                    card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, created_at
+                )
+                OUTPUT INSERTED.output_id
+                VALUES (%s, %s, %s, %s, %s, %s, SYSUTCDATETIME())
+                """,
+                (
+                    record.cardId,
+                    record.inputId,
+                    record.llmId,
+                    record.llmModel,
+                    json.dumps(record.llmUsage, ensure_ascii=False),
+                    json.dumps(record.content, ensure_ascii=False),
+                ),
+            )
+            row = cursor.fetchone()
+            output_id = int(row[0]) if row else 0
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise CardAIOutputDAOError("No fue posible guardar el resultado generado por IA.") from exc
+
+        connection.close()
+        return output_id
+
+    def listOutputsForCard(self, card_id: int, limit: int = 20) -> List[CardAIOutputRecord]:
+        """Return previous generations for the specified card."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardAIOutputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "SELECT TOP (%s) output_id, card_id, input_id, llm_id, llm_model, llm_usage_json,"
+                    " content_json, created_at FROM dbo.cards_ai_outputs WHERE card_id = %s"
+                    " ORDER BY created_at DESC, output_id DESC"
+                ),
+                (limit, card_id),
+            )
+            rows: Sequence[Sequence[object]] = cursor.fetchall() or []
+        except Exception as exc:  # pragma: no cover - depende del driver
+            connection.close()
+            raise CardAIOutputDAOError("No fue posible consultar el historial de resultados.") from exc
+
+        connection.close()
+        return [self._row_to_record(row) for row in rows]
+
+    def fetchById(self, output_id: int) -> Optional[CardAIOutputRecord]:
+        """Return a stored LLM generation by identifier."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardAIOutputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "SELECT output_id, card_id, input_id, llm_id, llm_model, llm_usage_json,"
+                    " content_json, created_at FROM dbo.cards_ai_outputs WHERE output_id = %s"
+                ),
+                (output_id,),
+            )
+            row = cursor.fetchone()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            connection.close()
+            raise CardAIOutputDAOError("No fue posible consultar el resultado almacenado.") from exc
+
+        connection.close()
+        if not row:
+            return None
+        return self._row_to_record(row)
+
+    def _row_to_record(self, row: Sequence[object]) -> CardAIOutputRecord:
+        """Translate a SQL row into a ``CardAIOutputRecord`` instance."""
+
+        usage_raw = row[5] if len(row) > 5 else None
+        content_raw = row[6] if len(row) > 6 else None
+        usage = {}
+        content = {}
+        if isinstance(usage_raw, (str, bytes)) and usage_raw:
+            try:
+                usage = json.loads(usage_raw)
+            except json.JSONDecodeError:
+                usage = {"raw": usage_raw}
+        if isinstance(content_raw, (str, bytes)) and content_raw:
+            try:
+                content = json.loads(content_raw)
+            except json.JSONDecodeError:
+                content = {"raw": content_raw}
+        return CardAIOutputRecord(
+            outputId=int(row[0]) if row[0] is not None else None,
+            cardId=int(row[1]) if row[1] is not None else 0,
+            inputId=int(row[2]) if row[2] is not None else None,
+            llmId=str(row[3]) if row[3] is not None else None,
+            llmModel=str(row[4]) if row[4] is not None else None,
+            llmUsage=usage,
+            content=content,
+            createdAt=_normalize_datetime(row[7] if len(row) > 7 else None),
+        )
+
+
+try:  # pragma: no cover - solo para tipado
+    import pymssql  # type: ignore  # noqa: F401
+except Exception:  # pragma: no cover - evita errores al generar documentación
+    pass

--- a/app/dtos/__init__.py
+++ b/app/dtos/__init__.py
@@ -1,1 +1,21 @@
 """Package for the desktop recorder application."""
+
+from app.dtos.card_ai_dto import (
+    CardAIInputPayload,
+    CardAIInputRecord,
+    CardAIOutputRecord,
+    CardFilters,
+    CardSummary,
+    GenerationResult,
+    LLMGenerationResponse,
+)
+
+__all__ = [
+    "CardAIInputPayload",
+    "CardAIInputRecord",
+    "CardAIOutputRecord",
+    "CardFilters",
+    "CardSummary",
+    "GenerationResult",
+    "LLMGenerationResponse",
+]

--- a/app/dtos/card_ai_dto.py
+++ b/app/dtos/card_ai_dto.py
@@ -1,0 +1,90 @@
+"""Data transfer objects for the card AI generation workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class CardFilters:
+    """Represent filter options used to load cards from the catalog."""
+
+    tipo: Optional[str]
+    status: Optional[str]
+    startDate: Optional[datetime]
+    endDate: Optional[datetime]
+    searchText: str
+
+
+@dataclass
+class CardSummary:
+    """Describe the key information displayed in the card listing."""
+
+    cardId: int
+    title: str
+    tipo: str
+    status: str
+    createdAt: Optional[datetime]
+
+
+@dataclass
+class CardAIInputPayload:
+    """Hold the raw values captured from the user interface."""
+
+    cardId: int
+    tipo: str
+    analisisDescProblema: Optional[str]
+    analisisRevisionSistema: Optional[str]
+    analisisDatos: Optional[str]
+    analisisCompReglas: Optional[str]
+    recoInvestigacion: Optional[str]
+    recoSolucionTemporal: Optional[str]
+    recoImplMejoras: Optional[str]
+    recoComStakeholders: Optional[str]
+    recoDocumentacion: Optional[str]
+
+
+@dataclass
+class CardAIInputRecord(CardAIInputPayload):
+    """Persisted representation of an input payload stored in SQL Server."""
+
+    inputId: Optional[int]
+    completenessPct: int
+    isDraft: bool
+    createdAt: Optional[datetime]
+    updatedAt: Optional[datetime]
+
+
+@dataclass
+class CardAIOutputRecord:
+    """Represent a stored LLM generation associated with a card."""
+
+    outputId: Optional[int]
+    cardId: int
+    inputId: Optional[int]
+    llmId: Optional[str]
+    llmModel: Optional[str]
+    llmUsage: Dict[str, Any]
+    content: Dict[str, Any]
+    createdAt: Optional[datetime]
+
+
+@dataclass
+class LLMGenerationResponse:
+    """Capture the relevant data returned by the LLM service."""
+
+    llmId: Optional[str]
+    model: Optional[str]
+    usage: Dict[str, Any]
+    content: Dict[str, Any]
+
+
+@dataclass
+class GenerationResult:
+    """Expose the data returned to the view after calling the LLM."""
+
+    inputRecord: CardAIInputRecord
+    outputRecord: CardAIOutputRecord
+    completenessPct: int

--- a/app/services/card_ai_service.py
+++ b/app/services/card_ai_service.py
@@ -1,0 +1,265 @@
+"""Business logic that orchestrates card listing and AI generation."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Iterable, List, Optional
+
+from app.daos.cards_dao import (
+    CardAIInputDAO,
+    CardAIInputDAOError,
+    CardAIOutputDAO,
+    CardAIOutputDAOError,
+    CardsDAO,
+    CardsDAOError,
+)
+from app.dtos.card_ai_dto import (
+    CardAIInputPayload,
+    CardAIInputRecord,
+    CardAIOutputRecord,
+    CardFilters,
+    CardSummary,
+    GenerationResult,
+)
+from app.services.card_prompt_builder import buildUserPrompt
+from app.services.llm_client import LLMClientError, LocalLLMClient
+
+
+class CardAIServiceError(RuntimeError):
+    """Raised when the card AI flow cannot be completed."""
+
+
+class CardAIService:
+    """Provide high-level operations for the DDE/HU generator."""
+
+    def __init__(
+        self,
+        cards_dao: CardsDAO,
+        inputs_dao: CardAIInputDAO,
+        outputs_dao: CardAIOutputDAO,
+        llm_client: LocalLLMClient,
+    ) -> None:
+        """Store dependencies used across service operations."""
+
+        self._cards_dao = cards_dao
+        self._inputs_dao = inputs_dao
+        self._outputs_dao = outputs_dao
+        self._llm_client = llm_client
+
+    def listCards(self, filters: Optional[CardFilters] = None, limit: int = 250) -> List[CardSummary]:
+        """Return cards applying filters both at SQL and in-memory level."""
+
+        try:
+            cards = self._cards_dao.listCards(filters, limit=limit)
+        except CardsDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        if not filters:
+            return cards
+
+        return self._applyFilters(cards, filters)
+
+    def _applyFilters(self, cards: Iterable[CardSummary], filters: CardFilters) -> List[CardSummary]:
+        """Apply client-side filters for search text and date ranges."""
+
+        results: List[CardSummary] = []
+        text = (filters.searchText or "").strip().lower()
+        start = filters.startDate
+        end = filters.endDate
+        if end and end.tzinfo is None:
+            end = end.replace(tzinfo=timezone.utc)
+        if start and start.tzinfo is None:
+            start = start.replace(tzinfo=timezone.utc)
+
+        for card in cards:
+            if text and text not in (card.title or "").lower():
+                continue
+            if start and card.createdAt and card.createdAt < start:
+                continue
+            if end and card.createdAt and card.createdAt > end:
+                continue
+            results.append(card)
+        return results
+
+    def calculateCompleteness(self, payload: CardAIInputPayload) -> int:
+        """Evaluate how many fields are filled to offer soft validation."""
+
+        values = [
+            payload.analisisDescProblema,
+            payload.analisisRevisionSistema,
+            payload.analisisDatos,
+            payload.analisisCompReglas,
+            payload.recoInvestigacion,
+            payload.recoSolucionTemporal,
+            payload.recoImplMejoras,
+            payload.recoComStakeholders,
+            payload.recoDocumentacion,
+        ]
+        total = len(values)
+        if total == 0:
+            return 0
+        filled = sum(1 for value in values if isinstance(value, str) and value.strip())
+        return round((filled / total) * 100)
+
+    def loadLatestInput(self, card_id: int) -> Optional[CardAIInputRecord]:
+        """Return the most recent captured input for the selected card."""
+
+        try:
+            return self._inputs_dao.fetchLatestForCard(card_id)
+        except CardAIInputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+    def saveDraft(self, payload: CardAIInputPayload) -> CardAIInputRecord:
+        """Persist a draft version of the captured inputs."""
+
+        completeness = self.calculateCompleteness(payload)
+        record = self._buildRecord(payload, completeness, is_draft=True)
+        try:
+            input_id = self._inputs_dao.insertInput(record)
+            stored = self._inputs_dao.fetchById(input_id)
+        except CardAIInputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+        if stored is None:
+            record.inputId = input_id
+            now = datetime.now(timezone.utc)
+            record.createdAt = now
+            record.updatedAt = now
+            return record
+        return stored
+
+    def generateDocument(self, payload: CardAIInputPayload) -> GenerationResult:
+        """Call the LLM using the provided payload and persist the outcome."""
+
+        card = self._ensureCardExists(payload.cardId)
+        completeness = self.calculateCompleteness(payload)
+        record = self._buildRecord(payload, completeness, is_draft=False)
+        try:
+            input_id = self._inputs_dao.insertInput(record)
+            stored_input = self._inputs_dao.fetchById(input_id) or record
+        except CardAIInputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        prompt = buildUserPrompt(record.tipo or card.tipo, card.title, asdict(record))
+        try:
+            generation = self._llm_client.generateJson(prompt)
+        except LLMClientError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        output = CardAIOutputRecord(
+            outputId=None,
+            cardId=record.cardId,
+            inputId=input_id,
+            llmId=generation.llmId,
+            llmModel=generation.model,
+            llmUsage=generation.usage,
+            content=generation.content,
+            createdAt=None,
+        )
+        try:
+            output_id = self._outputs_dao.insertOutput(output)
+            stored_output = self._outputs_dao.fetchById(output_id) or output
+        except CardAIOutputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        return GenerationResult(
+            inputRecord=stored_input,
+            outputRecord=stored_output,
+            completenessPct=completeness,
+        )
+
+    def regenerateFromInput(self, input_id: int) -> GenerationResult:
+        """Re-run the LLM using a previously stored input payload."""
+
+        try:
+            existing = self._inputs_dao.fetchById(input_id)
+        except CardAIInputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+        if existing is None:
+            raise CardAIServiceError("No se encontró el registro de entrada solicitado.")
+
+        card = self._ensureCardExists(existing.cardId)
+
+        if existing.isDraft:
+            try:
+                self._inputs_dao.updateDraftFlag(input_id, False)
+                existing.isDraft = False
+            except CardAIInputDAOError as exc:
+                raise CardAIServiceError(str(exc)) from exc
+
+        prompt = buildUserPrompt(existing.tipo or card.tipo, card.title, asdict(existing))
+        try:
+            generation = self._llm_client.generateJson(prompt)
+        except LLMClientError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        output = CardAIOutputRecord(
+            outputId=None,
+            cardId=existing.cardId,
+            inputId=input_id,
+            llmId=generation.llmId,
+            llmModel=generation.model,
+            llmUsage=generation.usage,
+            content=generation.content,
+            createdAt=None,
+        )
+        try:
+            output_id = self._outputs_dao.insertOutput(output)
+            stored_output = self._outputs_dao.fetchById(output_id) or output
+        except CardAIOutputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        return GenerationResult(
+            inputRecord=existing,
+            outputRecord=stored_output,
+            completenessPct=existing.completenessPct,
+        )
+
+    def listOutputs(self, card_id: int, limit: int = 20) -> List[CardAIOutputRecord]:
+        """Retrieve previous generations for the given card."""
+
+        try:
+            return self._outputs_dao.listOutputsForCard(card_id, limit=limit)
+        except CardAIOutputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+    def _buildRecord(
+        self,
+        payload: CardAIInputPayload,
+        completeness: int,
+        is_draft: bool,
+    ) -> CardAIInputRecord:
+        """Construct an input record ready for persistence."""
+
+        return CardAIInputRecord(
+            inputId=None,
+            cardId=payload.cardId,
+            tipo=(payload.tipo or "").strip() or "HU",
+            analisisDescProblema=payload.analisisDescProblema,
+            analisisRevisionSistema=payload.analisisRevisionSistema,
+            analisisDatos=payload.analisisDatos,
+            analisisCompReglas=payload.analisisCompReglas,
+            recoInvestigacion=payload.recoInvestigacion,
+            recoSolucionTemporal=payload.recoSolucionTemporal,
+            recoImplMejoras=payload.recoImplMejoras,
+            recoComStakeholders=payload.recoComStakeholders,
+            recoDocumentacion=payload.recoDocumentacion,
+            completenessPct=completeness,
+            isDraft=is_draft,
+            createdAt=None,
+            updatedAt=None,
+        )
+
+    def _ensureCardExists(self, card_id: int) -> CardSummary:
+        """Retrieve the card summary or raise a domain error."""
+
+        try:
+            card = self._cards_dao.fetchCard(card_id)
+        except CardsDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+        if card is None:
+            raise CardAIServiceError("La tarjeta seleccionada no existe en la base de datos.")
+        return card
+
+
+__all__ = ["CardAIService", "CardAIServiceError"]

--- a/app/services/card_prompt_builder.py
+++ b/app/services/card_prompt_builder.py
@@ -1,0 +1,69 @@
+"""Utilities to assemble prompts for the card AI generator."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import Any, Mapping
+
+
+def buildUserPrompt(tipo: str, tituloCard: str, inputs: Any) -> str:
+    """Create the prompt sent to the language model."""
+
+    if inputs is None:
+        data: Mapping[str, Any] = {}
+    elif is_dataclass(inputs):
+        data = asdict(inputs)
+    elif isinstance(inputs, Mapping):
+        data = inputs
+    else:
+        data = {}
+
+    def _value(key: str) -> str:
+        """Return a safe string value for the given key."""
+
+        raw = data.get(key, "") if isinstance(data, Mapping) else ""
+        return str(raw or "").strip()
+
+    analisis = (
+        "### Análisis\n"
+        f"1. Descripción del Problema: {_value('analisisDescProblema')}\n"
+        f"2. Revisión del Sistema: {_value('analisisRevisionSistema')}\n"
+        f"3. Análisis de Datos: {_value('analisisDatos')}\n"
+        f"4. Comparación con Reglas Establecidas: {_value('analisisCompReglas')}"
+    )
+
+    recomendacion = (
+        "### Recomendación\n"
+        f"1. Investigación y Diagnóstico: {_value('recoInvestigacion')}\n"
+        f"2. Solución Temporal: {_value('recoSolucionTemporal')}\n"
+        f"3. Implementación de Mejoras: {_value('recoImplMejoras')}\n"
+        f"4. Comunicación con los Stakeholders: {_value('recoComStakeholders')}\n"
+        f"5. Documentación: {_value('recoDocumentacion')}"
+    )
+
+    instruccion_salida = (
+        "Genera la respuesta **en JSON** con el siguiente esquema de claves EXACTAS:\n"
+        "{\n"
+        '  "titulo": string,\n'
+        '  "fecha": string,\n'
+        '  "hora_inicio": string,\n'
+        '  "hora_fin": string,\n'
+        '  "lugar": string,\n'
+        '  "encabezado_tipo": string,\n'
+        '  "descripcion": string,\n'
+        '  "que_necesitas": string,\n'
+        '  "para_que": string,\n'
+        '  "como_necesitas": string,\n'
+        '  "requerimientos_funcionales": string[],\n'
+        '  "requerimientos_especiales": string[],\n'
+        '  "criterios_aceptacion": string[]\n'
+        "}\n"
+        "Devuelve SOLO el JSON, sin texto adicional."
+    )
+
+    encabezado = f"{(tipo or '').strip()}: {tituloCard}".strip()
+
+    return f"{encabezado}\n\n{analisis}\n\n{recomendacion}\n\n{instruccion_salida}\n"
+
+
+__all__ = ["buildUserPrompt"]

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1,0 +1,119 @@
+"""HTTP client to interact with the local LM Studio endpoint."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Mapping, Optional
+
+try:  # pragma: no cover - dependencia opcional en pruebas
+    import requests  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - entornos sin requests
+    requests = None  # type: ignore
+
+from app.dtos.card_ai_dto import LLMGenerationResponse
+
+
+class LLMClientError(RuntimeError):
+    """Raised when the LLM endpoint cannot process a request."""
+
+
+class LocalLLMClient:
+    """Small wrapper around the OpenAI-compatible LM Studio endpoint."""
+
+    DEFAULT_URL = "http://127.0.0.1:1234/v1/chat/completions"
+    DEFAULT_MODEL = "qwen/qwen2.5-vl-7b"
+
+    def __init__(
+        self,
+        endpoint: Optional[str] = None,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        timeout_seconds: int = 180,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        """Store configuration for subsequent invocations."""
+
+        self._endpoint = (endpoint or os.getenv("LM_URL") or self.DEFAULT_URL).strip()
+        self._model = (model or os.getenv("LM_MODEL") or self.DEFAULT_MODEL).strip()
+        self._api_key = (api_key or os.getenv("LM_API_KEY") or "local").strip()
+        self._timeout = timeout_seconds
+        if session is not None:
+            self._session = session
+        elif requests is not None:
+            self._session = requests.Session()
+        else:  # pragma: no cover - depende del entorno de ejecución
+            self._session = None
+
+    def generateJson(self, prompt: str) -> LLMGenerationResponse:
+        """Request a JSON-formatted completion from the language model."""
+
+        payload: Dict[str, Any] = {
+            "model": self._model,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.35,
+            "top_p": 0.9,
+            "max_tokens": 3000,
+        }
+
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        if self._session is None:  # pragma: no cover - depende del entorno
+            raise LLMClientError(
+                "La dependencia 'requests' no está instalada. Ejecuta 'pip install requests' para habilitar el cliente LLM."
+            )
+
+        try:
+            response = self._session.post(
+                self._endpoint,
+                headers=headers,
+                data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                timeout=self._timeout,
+            )
+        except Exception as exc:  # pragma: no cover - depende del driver HTTP
+            raise LLMClientError("No fue posible contactar al servicio de lenguaje natural.") from exc
+
+        if not response.ok:
+            raise LLMClientError(
+                f"El servicio de lenguaje natural respondió con código {response.status_code}."
+            )
+
+        try:
+            data: Mapping[str, Any] = response.json()
+        except json.JSONDecodeError as exc:
+            raise LLMClientError("La respuesta del modelo no es un JSON válido.") from exc
+
+        try:
+            choices = data["choices"]
+            first = choices[0]
+            message = first["message"]
+            content_raw = message["content"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise LLMClientError("La respuesta del modelo no contiene el contenido esperado.") from exc
+
+        if isinstance(content_raw, (str, bytes)):
+            content_text = content_raw.decode("utf-8") if isinstance(content_raw, bytes) else content_raw
+            try:
+                content = json.loads(content_text)
+            except json.JSONDecodeError as exc:
+                raise LLMClientError("El modelo no devolvió un JSON válido en el contenido.") from exc
+        elif isinstance(content_raw, Mapping):
+            content = dict(content_raw)
+        else:
+            raise LLMClientError("El contenido devuelto por el modelo tiene un formato desconocido.")
+
+        usage = {}
+        if isinstance(data.get("usage"), Mapping):
+            usage = dict(data["usage"])
+
+        return LLMGenerationResponse(
+            llmId=str(data.get("id")) if data.get("id") else None,
+            model=str(data.get("model")) if data.get("model") else self._model,
+            usage=usage,
+            content=content,
+        )
+
+
+__all__ = ["LocalLLMClient", "LLMClientError"]

--- a/app/views/generar_dde_hu_view.py
+++ b/app/views/generar_dde_hu_view.py
@@ -95,17 +95,21 @@ def buildGenerarDdeHuView(
 
         status_var.set("Cargando tarjetas...")
 
-        def worker() -> None:
+        selected_tipo = tipo_var.get() or None
+        selected_status = status_filter_var.get() or None
+        search_text = search_var.get() or ""
+        local_filters = CardFilters(
+            tipo=selected_tipo,
+            status=selected_status,
+            startDate=None,
+            endDate=None,
+            searchText=search_text,
+        )
+
+        def worker(filters: CardFilters) -> None:
             nonlocal cards_data
-            local_filters = CardFilters(
-                tipo=tipo_var.get() or None,
-                status=status_filter_var.get() or None,
-                startDate=None,
-                endDate=None,
-                searchText=search_var.get() or "",
-            )
             try:
-                result = controller.listCards(local_filters)
+                result = controller.listCards(filters)
             except CardsControllerError as exc:
                 error_message = str(exc)
                 root.after(0, lambda msg=error_message: Messagebox.showerror("Tarjetas", msg))
@@ -132,7 +136,7 @@ def buildGenerarDdeHuView(
 
             root.after(0, apply)
 
-        threading.Thread(target=worker, daemon=True).start()
+        threading.Thread(target=worker, args=(local_filters,), daemon=True).start()
 
     def _on_search_change(*_) -> None:
         """Debounce the search field updates."""

--- a/app/views/generar_dde_hu_view.py
+++ b/app/views/generar_dde_hu_view.py
@@ -1,0 +1,542 @@
+"""User interface for the DDE/HU generator powered by a local LLM."""
+
+from __future__ import annotations
+
+import json
+import threading
+from typing import Callable, Dict, List, Optional
+import tkinter as tk
+from tkinter import filedialog, ttk
+
+import ttkbootstrap as tb
+from ttkbootstrap.constants import *  # noqa: F401,F403
+
+from app.controllers.cards_controller import CardsController, CardsControllerError
+from app.dtos.card_ai_dto import CardAIInputPayload, CardFilters
+
+
+TYPE_OPTIONS = ["", "INCIDENCIA", "MEJORA", "HU"]
+STATUS_OPTIONS = ["", "pending", "in_progress", "done", "closed"]
+
+
+def buildGenerarDdeHuView(
+    root: tk.Misc,
+    parent: tb.Frame,
+    controller: CardsController,
+    messagebox_service,
+    bind_mousewheel: Callable[[tk.Widget, Callable[..., None]], None],
+) -> None:
+    """Render the AI-assisted document generator inside ``parent``."""
+
+    Messagebox = messagebox_service
+
+    for child in parent.winfo_children():
+        child.destroy()
+
+    selected_card_id = tk.IntVar(value=0)
+    status_var = tk.StringVar(value="Listo para iniciar.")
+    completeness_var = tk.IntVar(value=0)
+
+    cards_data: List[Dict[str, object]] = []
+    history_data: List[Dict[str, object]] = []
+    current_result: Optional[Dict[str, object]] = None
+
+    container = tb.Panedwindow(parent, orient="horizontal")
+    container.pack(fill=BOTH, expand=YES)
+
+    list_frame = tb.Frame(container, padding=10)
+    form_frame = tb.Frame(container, padding=10)
+    container.add(list_frame, weight=1)
+    container.add(form_frame, weight=2)
+
+    # --- Card filters and listing ---
+    tb.Label(list_frame, text="Tarjetas", font=("Segoe UI", 12, "bold")).pack(anchor=W)
+    filters_frame = tb.Frame(list_frame)
+    filters_frame.pack(fill=X, pady=(6, 8))
+
+    tb.Label(filters_frame, text="Tipo").grid(row=0, column=0, sticky="w")
+    tipo_var = tk.StringVar(value="")
+    tipo_combo = tb.Combobox(filters_frame, textvariable=tipo_var, values=TYPE_OPTIONS, state="readonly")
+    tipo_combo.grid(row=1, column=0, sticky="we", padx=(0, 6))
+
+    tb.Label(filters_frame, text="Status").grid(row=0, column=1, sticky="w")
+    status_filter_var = tk.StringVar(value="")
+    status_combo = tb.Combobox(filters_frame, textvariable=status_filter_var, values=STATUS_OPTIONS, state="readonly")
+    status_combo.grid(row=1, column=1, sticky="we", padx=(0, 6))
+
+    tb.Label(filters_frame, text="Buscar").grid(row=0, column=2, sticky="w")
+    search_var = tk.StringVar(value="")
+    search_entry = tb.Entry(filters_frame, textvariable=search_var)
+    search_entry.grid(row=1, column=2, sticky="we")
+
+    for column in range(3):
+        filters_frame.grid_columnconfigure(column, weight=1)
+
+    cards_tree = ttk.Treeview(list_frame, show="headings", columns=("id", "title", "tipo", "status", "fecha"), height=18)
+    cards_tree.heading("id", text="ID")
+    cards_tree.heading("title", text="Título")
+    cards_tree.heading("tipo", text="Tipo")
+    cards_tree.heading("status", text="Status")
+    cards_tree.heading("fecha", text="Fecha")
+    cards_tree.column("id", width=70, anchor="center")
+    cards_tree.column("title", width=220, anchor="w")
+    cards_tree.column("tipo", width=110, anchor="center")
+    cards_tree.column("status", width=120, anchor="center")
+    cards_tree.column("fecha", width=140, anchor="center")
+    cards_tree.pack(fill=BOTH, expand=YES)
+
+    cards_scroll = ttk.Scrollbar(list_frame, orient="vertical", command=cards_tree.yview)
+    cards_tree.configure(yscrollcommand=cards_scroll.set)
+    cards_scroll.pack(fill=Y, side=RIGHT)
+    bind_mousewheel(cards_tree, cards_tree.yview)
+
+    def _refresh_cards_async() -> None:
+        """Load cards from the controller in a background thread."""
+
+        status_var.set("Cargando tarjetas...")
+
+        def worker() -> None:
+            nonlocal cards_data
+            local_filters = CardFilters(
+                tipo=tipo_var.get() or None,
+                status=status_filter_var.get() or None,
+                startDate=None,
+                endDate=None,
+                searchText=search_var.get() or "",
+            )
+            try:
+                result = controller.listCards(local_filters)
+            except CardsControllerError as exc:
+                root.after(0, lambda: Messagebox.showerror("Tarjetas", str(exc)))
+                root.after(0, lambda: status_var.set("No fue posible cargar las tarjetas."))
+                return
+
+            def apply() -> None:
+                nonlocal cards_data
+                cards_data = []
+                cards_tree.delete(*cards_tree.get_children())
+                for card in result:
+                    cards_data.append(
+                        {
+                            "id": card.cardId,
+                            "title": card.title,
+                            "tipo": card.tipo,
+                            "status": card.status,
+                            "fecha": card.createdAt,
+                        }
+                    )
+                    fecha_txt = card.createdAt.astimezone().strftime("%Y-%m-%d %H:%M") if card.createdAt else ""
+                    cards_tree.insert("", "end", values=(card.cardId, card.title, card.tipo, card.status, fecha_txt))
+                status_var.set(f"Tarjetas cargadas: {len(cards_data)}")
+
+            root.after(0, apply)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _on_search_change(*_) -> None:
+        """Debounce the search field updates."""
+
+        if hasattr(_on_search_change, "_after_id") and _on_search_change._after_id:
+            root.after_cancel(_on_search_change._after_id)
+        _on_search_change._after_id = root.after(300, _refresh_cards_async)
+
+    _on_search_change._after_id = None  # type: ignore[attr-defined]
+
+    tipo_combo.bind("<<ComboboxSelected>>", lambda _: _refresh_cards_async())
+    status_combo.bind("<<ComboboxSelected>>", lambda _: _refresh_cards_async())
+    search_var.trace_add("write", _on_search_change)
+
+    # --- Form definition ---
+    header = tb.Frame(form_frame)
+    header.pack(fill=X)
+    tb.Label(header, text="Generar DDE/HU", font=("Segoe UI", 12, "bold")).pack(side=LEFT)
+    tb.Label(header, textvariable=status_var, bootstyle=SECONDARY).pack(side=RIGHT)
+
+    form_fields = tb.Labelframe(form_frame, text="Captura", padding=10)
+    form_fields.pack(fill=BOTH, expand=YES, pady=(8, 0))
+
+    tb.Label(form_fields, text="Tipo").grid(row=0, column=0, sticky="w", pady=(0, 4))
+    tipo_form_var = tk.StringVar(value="HU")
+    tipo_form_combo = tb.Combobox(form_fields, textvariable=tipo_form_var, values=TYPE_OPTIONS, state="readonly")
+    tipo_form_combo.grid(row=0, column=1, sticky="w", padx=(0, 6))
+
+    completeness_label = tb.Label(form_fields, text="Completitud: 0%", bootstyle=DANGER)
+    completeness_label.grid(row=0, column=2, sticky="e", padx=(20, 0))
+
+    text_fields: Dict[str, tk.Text] = {}
+
+    def _add_text_row(row: int, label: str, key: str) -> None:
+        """Create a labeled Text widget bound to a payload key."""
+
+        tb.Label(form_fields, text=label).grid(row=row, column=0, columnspan=3, sticky="w", pady=(6, 2))
+        widget = tk.Text(form_fields, height=4, wrap="word")
+        widget.configure(font=("Segoe UI", 10))
+        widget.grid(row=row + 1, column=0, columnspan=3, sticky="nsew", pady=(0, 6))
+        form_fields.grid_rowconfigure(row + 1, weight=1)
+        text_fields[key] = widget
+        bind_mousewheel(widget, widget.yview)
+        widget.bind("<KeyRelease>", lambda _e: _update_completeness())
+
+    _add_text_row(1, "Descripción del Problema", "analisisDescProblema")
+    _add_text_row(3, "Revisión del Sistema", "analisisRevisionSistema")
+    _add_text_row(5, "Análisis de Datos", "analisisDatos")
+    _add_text_row(7, "Comparación con Reglas Establecidas", "analisisCompReglas")
+    _add_text_row(9, "Investigación y Diagnóstico", "recoInvestigacion")
+    _add_text_row(11, "Solución Temporal", "recoSolucionTemporal")
+    _add_text_row(13, "Implementación de Mejoras", "recoImplMejoras")
+    _add_text_row(15, "Comunicación con Stakeholders", "recoComStakeholders")
+    _add_text_row(17, "Documentación", "recoDocumentacion")
+
+    def _clear_form() -> None:
+        """Reset the capture fields to their defaults."""
+
+        tipo_form_var.set("HU")
+        for widget in text_fields.values():
+            widget.delete("1.0", tk.END)
+        completeness_var.set(0)
+        completeness_label.configure(text="Completitud: 0%", bootstyle=DANGER)
+
+    def _set_form_from_payload(payload: CardAIInputPayload) -> None:
+        """Populate the form widgets from an existing payload."""
+
+        tipo_form_var.set((payload.tipo or "HU").upper())
+        text_fields["analisisDescProblema"].delete("1.0", tk.END)
+        text_fields["analisisDescProblema"].insert(tk.END, payload.analisisDescProblema or "")
+        text_fields["analisisRevisionSistema"].delete("1.0", tk.END)
+        text_fields["analisisRevisionSistema"].insert(tk.END, payload.analisisRevisionSistema or "")
+        text_fields["analisisDatos"].delete("1.0", tk.END)
+        text_fields["analisisDatos"].insert(tk.END, payload.analisisDatos or "")
+        text_fields["analisisCompReglas"].delete("1.0", tk.END)
+        text_fields["analisisCompReglas"].insert(tk.END, payload.analisisCompReglas or "")
+        text_fields["recoInvestigacion"].delete("1.0", tk.END)
+        text_fields["recoInvestigacion"].insert(tk.END, payload.recoInvestigacion or "")
+        text_fields["recoSolucionTemporal"].delete("1.0", tk.END)
+        text_fields["recoSolucionTemporal"].insert(tk.END, payload.recoSolucionTemporal or "")
+        text_fields["recoImplMejoras"].delete("1.0", tk.END)
+        text_fields["recoImplMejoras"].insert(tk.END, payload.recoImplMejoras or "")
+        text_fields["recoComStakeholders"].delete("1.0", tk.END)
+        text_fields["recoComStakeholders"].insert(tk.END, payload.recoComStakeholders or "")
+        text_fields["recoDocumentacion"].delete("1.0", tk.END)
+        text_fields["recoDocumentacion"].insert(tk.END, payload.recoDocumentacion or "")
+        _update_completeness()
+
+    def _gather_payload() -> Optional[CardAIInputPayload]:
+        """Collect current form values into a payload object."""
+
+        card_id = selected_card_id.get()
+        if not card_id:
+            Messagebox.showwarning("Generar", "Selecciona una tarjeta antes de capturar información.")
+            return None
+        payload = CardAIInputPayload(
+            cardId=card_id,
+            tipo=tipo_form_var.get() or "HU",
+            analisisDescProblema=text_fields["analisisDescProblema"].get("1.0", tk.END).strip(),
+            analisisRevisionSistema=text_fields["analisisRevisionSistema"].get("1.0", tk.END).strip(),
+            analisisDatos=text_fields["analisisDatos"].get("1.0", tk.END).strip(),
+            analisisCompReglas=text_fields["analisisCompReglas"].get("1.0", tk.END).strip(),
+            recoInvestigacion=text_fields["recoInvestigacion"].get("1.0", tk.END).strip(),
+            recoSolucionTemporal=text_fields["recoSolucionTemporal"].get("1.0", tk.END).strip(),
+            recoImplMejoras=text_fields["recoImplMejoras"].get("1.0", tk.END).strip(),
+            recoComStakeholders=text_fields["recoComStakeholders"].get("1.0", tk.END).strip(),
+            recoDocumentacion=text_fields["recoDocumentacion"].get("1.0", tk.END).strip(),
+        )
+        return payload
+
+    def _update_completeness(*_) -> None:
+        """Refresh the completeness indicator according to form data."""
+
+        if not selected_card_id.get():
+            completeness_label.configure(text="Completitud: 0%", bootstyle=DANGER)
+            completeness_var.set(0)
+            return
+        payload = CardAIInputPayload(
+            cardId=selected_card_id.get(),
+            tipo=tipo_form_var.get() or "HU",
+            analisisDescProblema=text_fields["analisisDescProblema"].get("1.0", tk.END).strip(),
+            analisisRevisionSistema=text_fields["analisisRevisionSistema"].get("1.0", tk.END).strip(),
+            analisisDatos=text_fields["analisisDatos"].get("1.0", tk.END).strip(),
+            analisisCompReglas=text_fields["analisisCompReglas"].get("1.0", tk.END).strip(),
+            recoInvestigacion=text_fields["recoInvestigacion"].get("1.0", tk.END).strip(),
+            recoSolucionTemporal=text_fields["recoSolucionTemporal"].get("1.0", tk.END).strip(),
+            recoImplMejoras=text_fields["recoImplMejoras"].get("1.0", tk.END).strip(),
+            recoComStakeholders=text_fields["recoComStakeholders"].get("1.0", tk.END).strip(),
+            recoDocumentacion=text_fields["recoDocumentacion"].get("1.0", tk.END).strip(),
+        )
+        pct = controller.calculateCompleteness(payload)
+        completeness_var.set(pct)
+        bootstyle = DANGER
+        if pct >= 67:
+            bootstyle = SUCCESS
+        elif pct >= 34:
+            bootstyle = WARNING
+        completeness_label.configure(text=f"Completitud: {pct}%", bootstyle=bootstyle)
+
+    tipo_form_combo.bind("<<ComboboxSelected>>", _update_completeness)
+
+    # --- Result preview and history ---
+    result_frame = tb.Labelframe(form_frame, text="Resultado", padding=10)
+    result_frame.pack(fill=BOTH, expand=YES, pady=(8, 0))
+
+    result_text = tk.Text(result_frame, height=12, wrap="word")
+    result_text.configure(font=("Consolas", 10))
+    result_text.pack(fill=BOTH, expand=YES, side=LEFT)
+    bind_mousewheel(result_text, result_text.yview)
+
+    history_frame = tb.Frame(result_frame, padding=(6, 0))
+    history_frame.pack(fill=Y, side=RIGHT)
+
+    tb.Label(history_frame, text="Historial", font=("Segoe UI", 10, "bold")).pack(anchor=W)
+    history_tree = ttk.Treeview(history_frame, show="headings", columns=("id", "fecha", "modelo", "input"), height=12)
+    history_tree.heading("id", text="Output")
+    history_tree.heading("fecha", text="Fecha")
+    history_tree.heading("modelo", text="Modelo")
+    history_tree.heading("input", text="Input")
+    history_tree.column("id", width=80, anchor="center")
+    history_tree.column("fecha", width=140, anchor="center")
+    history_tree.column("modelo", width=120, anchor="center")
+    history_tree.column("input", width=80, anchor="center")
+    history_tree.pack(fill=BOTH, expand=YES)
+    bind_mousewheel(history_tree, history_tree.yview)
+
+    history_scroll = ttk.Scrollbar(history_frame, orient="vertical", command=history_tree.yview)
+    history_tree.configure(yscrollcommand=history_scroll.set)
+    history_scroll.pack(fill=Y, side=RIGHT)
+
+    def _display_result(data: Optional[Dict[str, object]]) -> None:
+        """Show the JSON result in the preview widget."""
+
+        nonlocal current_result
+        current_result = data
+        result_text.delete("1.0", tk.END)
+        if not data:
+            return
+        try:
+            pretty = json.dumps(data, indent=2, ensure_ascii=False)
+        except (TypeError, ValueError):
+            pretty = str(data)
+        result_text.insert(tk.END, pretty)
+
+    def _load_history(card_id: int) -> None:
+        """Fetch history entries for the selected card."""
+
+        history_tree.delete(*history_tree.get_children())
+        history_data.clear()
+
+        def worker() -> None:
+            try:
+                outputs = controller.listOutputs(card_id)
+            except CardsControllerError as exc:
+                root.after(0, lambda: Messagebox.showerror("Historial", str(exc)))
+                return
+
+            def apply() -> None:
+                history_tree.delete(*history_tree.get_children())
+                history_data.clear()
+                for output in outputs:
+                    created_txt = output.createdAt.astimezone().strftime("%Y-%m-%d %H:%M") if output.createdAt else ""
+                    history_tree.insert(
+                        "",
+                        "end",
+                        values=(output.outputId or "", created_txt, output.llmModel or "", output.inputId or ""),
+                    )
+                    history_data.append(
+                        {
+                            "outputId": output.outputId,
+                            "inputId": output.inputId,
+                            "content": output.content,
+                        }
+                    )
+
+            root.after(0, apply)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _on_card_selected(_event=None) -> None:
+        """React when the user selects a different card."""
+
+        selection = cards_tree.selection()
+        if not selection:
+            return
+        item_id = selection[0]
+        values = cards_tree.item(item_id, "values")
+        if not values:
+            return
+        card_id = int(values[0])
+        selected_card_id.set(card_id)
+        status_var.set(f"Tarjeta seleccionada: {card_id}")
+        _clear_form()
+        _display_result(None)
+        _load_history(card_id)
+
+        def worker() -> None:
+            try:
+                latest = controller.loadLatestInput(card_id)
+            except CardsControllerError as exc:
+                root.after(0, lambda: Messagebox.showerror("Entradas", str(exc)))
+                return
+
+            if latest is None:
+                return
+
+            payload = CardAIInputPayload(
+                cardId=card_id,
+                tipo=latest.tipo,
+                analisisDescProblema=latest.analisisDescProblema,
+                analisisRevisionSistema=latest.analisisRevisionSistema,
+                analisisDatos=latest.analisisDatos,
+                analisisCompReglas=latest.analisisCompReglas,
+                recoInvestigacion=latest.recoInvestigacion,
+                recoSolucionTemporal=latest.recoSolucionTemporal,
+                recoImplMejoras=latest.recoImplMejoras,
+                recoComStakeholders=latest.recoComStakeholders,
+                recoDocumentacion=latest.recoDocumentacion,
+            )
+
+            root.after(0, lambda: _set_form_from_payload(payload))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    cards_tree.bind("<<TreeviewSelect>>", _on_card_selected)
+
+    def _save_draft() -> None:
+        """Persist the captured inputs as a draft."""
+
+        payload = _gather_payload()
+        if payload is None:
+            return
+
+        status_var.set("Guardando borrador...")
+
+        def worker() -> None:
+            try:
+                record = controller.saveDraft(payload)
+            except CardsControllerError as exc:
+                root.after(0, lambda: Messagebox.showerror("Borrador", str(exc)))
+                root.after(0, lambda: status_var.set("Error al guardar el borrador."))
+                return
+            root.after(0, lambda: status_var.set(f"Borrador guardado #{record.inputId}."))
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _generate_document() -> None:
+        """Call the LLM and display the generated document."""
+
+        payload = _gather_payload()
+        if payload is None:
+            return
+        pct = controller.calculateCompleteness(payload)
+        if pct < 34:
+            if not Messagebox.askyesno(
+                "Baja completitud",
+                "La captura tiene menos del 34% de completitud. ¿Deseas generar de todos modos?",
+            ):
+                return
+
+        status_var.set("Generando documento con IA...")
+
+        def worker() -> None:
+            try:
+                result = controller.generateDocument(payload)
+            except CardsControllerError as exc:
+                root.after(0, lambda: Messagebox.showerror("Generar", str(exc)))
+                root.after(0, lambda: status_var.set("Error al generar el documento."))
+                return
+
+            def apply() -> None:
+                status_var.set("Documento generado correctamente.")
+                _display_result(result.outputRecord.content)
+                _load_history(payload.cardId)
+                _update_completeness()
+
+            root.after(0, apply)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _regenerate_from_history() -> None:
+        """Re-launch the LLM based on the selected history entry."""
+
+        selection = history_tree.selection()
+        if not selection:
+            Messagebox.showinfo("Historial", "Selecciona un resultado para regenerar.")
+            return
+        item = selection[0]
+        values = history_tree.item(item, "values")
+        if not values:
+            return
+        input_id = values[3]
+        if not input_id:
+            Messagebox.showwarning("Historial", "El elemento seleccionado no tiene entradas asociadas.")
+            return
+        try:
+            input_id_int = int(input_id)
+        except ValueError:
+            Messagebox.showwarning("Historial", "El identificador de entrada es inválido.")
+            return
+
+        status_var.set("Regenerando documento...")
+
+        def worker() -> None:
+            try:
+                result = controller.regenerateFromInput(input_id_int)
+            except CardsControllerError as exc:
+                root.after(0, lambda: Messagebox.showerror("Regenerar", str(exc)))
+                root.after(0, lambda: status_var.set("Error al regenerar el documento."))
+                return
+
+            def apply() -> None:
+                status_var.set("Documento regenerado correctamente.")
+                _display_result(result.outputRecord.content)
+                _load_history(result.inputRecord.cardId)
+
+            root.after(0, apply)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _on_history_select(_event=None) -> None:
+        """Show the JSON for the selected history row."""
+
+        selection = history_tree.selection()
+        if not selection:
+            return
+        index = history_tree.index(selection[0])
+        if 0 <= index < len(history_data):
+            _display_result(history_data[index]["content"])
+
+    history_tree.bind("<<TreeviewSelect>>", _on_history_select)
+
+    def _export_json() -> None:
+        """Save the current JSON result to disk."""
+
+        if not current_result:
+            Messagebox.showinfo("Exportar", "No hay un resultado para exportar.")
+            return
+        path = filedialog.asksaveasfilename(
+            title="Guardar resultado",
+            defaultextension=".json",
+            filetypes=(("JSON", "*.json"), ("Todos", "*.*")),
+        )
+        if not path:
+            return
+        try:
+            with open(path, "w", encoding="utf-8") as handle:
+                json.dump(current_result, handle, ensure_ascii=False, indent=2)
+        except OSError as exc:
+            Messagebox.showerror("Exportar", f"No fue posible guardar el archivo:\n{exc}")
+            return
+        Messagebox.showinfo("Exportar", f"Resultado guardado en:\n{path}")
+
+    buttons = tb.Frame(form_frame)
+    buttons.pack(fill=X, pady=(10, 0))
+    tb.Button(buttons, text="Guardar borrador", bootstyle=SECONDARY, command=_save_draft).pack(side=LEFT)
+    tb.Button(buttons, text="Generar", bootstyle=PRIMARY, command=_generate_document).pack(side=LEFT, padx=(10, 0))
+    tb.Button(buttons, text="Regenerar", bootstyle=INFO, command=_regenerate_from_history).pack(side=LEFT, padx=(10, 0))
+    tb.Button(buttons, text="Exportar JSON", bootstyle=SUCCESS, command=_export_json).pack(side=LEFT, padx=(10, 0))
+    tb.Button(buttons, text="Limpiar", bootstyle=LIGHT, command=_clear_form).pack(side=LEFT, padx=(10, 0))
+
+    _refresh_cards_async()
+
+
+build_generar_dde_hu_view = buildGenerarDdeHuView
+
+
+__all__ = ["buildGenerarDdeHuView", "build_generar_dde_hu_view"]

--- a/app/views/generar_dde_hu_view.py
+++ b/app/views/generar_dde_hu_view.py
@@ -107,7 +107,8 @@ def buildGenerarDdeHuView(
             try:
                 result = controller.listCards(local_filters)
             except CardsControllerError as exc:
-                root.after(0, lambda: Messagebox.showerror("Tarjetas", str(exc)))
+                error_message = str(exc)
+                root.after(0, lambda msg=error_message: Messagebox.showerror("Tarjetas", msg))
                 root.after(0, lambda: status_var.set("No fue posible cargar las tarjetas."))
                 return
 
@@ -326,7 +327,8 @@ def buildGenerarDdeHuView(
             try:
                 outputs = controller.listOutputs(card_id)
             except CardsControllerError as exc:
-                root.after(0, lambda: Messagebox.showerror("Historial", str(exc)))
+                error_message = str(exc)
+                root.after(0, lambda msg=error_message: Messagebox.showerror("Historial", msg))
                 return
 
             def apply() -> None:
@@ -372,7 +374,8 @@ def buildGenerarDdeHuView(
             try:
                 latest = controller.loadLatestInput(card_id)
             except CardsControllerError as exc:
-                root.after(0, lambda: Messagebox.showerror("Entradas", str(exc)))
+                error_message = str(exc)
+                root.after(0, lambda msg=error_message: Messagebox.showerror("Entradas", msg))
                 return
 
             if latest is None:
@@ -411,7 +414,8 @@ def buildGenerarDdeHuView(
             try:
                 record = controller.saveDraft(payload)
             except CardsControllerError as exc:
-                root.after(0, lambda: Messagebox.showerror("Borrador", str(exc)))
+                error_message = str(exc)
+                root.after(0, lambda msg=error_message: Messagebox.showerror("Borrador", msg))
                 root.after(0, lambda: status_var.set("Error al guardar el borrador."))
                 return
             root.after(0, lambda: status_var.set(f"Borrador guardado #{record.inputId}."))
@@ -438,7 +442,8 @@ def buildGenerarDdeHuView(
             try:
                 result = controller.generateDocument(payload)
             except CardsControllerError as exc:
-                root.after(0, lambda: Messagebox.showerror("Generar", str(exc)))
+                error_message = str(exc)
+                root.after(0, lambda msg=error_message: Messagebox.showerror("Generar", msg))
                 root.after(0, lambda: status_var.set("Error al generar el documento."))
                 return
 
@@ -479,7 +484,8 @@ def buildGenerarDdeHuView(
             try:
                 result = controller.regenerateFromInput(input_id_int)
             except CardsControllerError as exc:
-                root.after(0, lambda: Messagebox.showerror("Regenerar", str(exc)))
+                error_message = str(exc)
+                root.after(0, lambda msg=error_message: Messagebox.showerror("Regenerar", msg))
                 root.after(0, lambda: status_var.set("Error al regenerar el documento."))
                 return
 

--- a/app/views/main_view.py
+++ b/app/views/main_view.py
@@ -79,6 +79,7 @@ from app.controllers.main_controller import MainController
 from app.dtos.auth_result import AuthenticationResult, AuthenticationStatus
 from app.views.generacion_automatica_view import build_generacion_automatica_view
 from app.views.generacion_manual_view import build_generacion_manual_view
+from app.views.generar_dde_hu_view import build_generar_dde_hu_view
 from app.views.modificacion_matriz_view import build_modificacion_matriz_view
 from app.views.alta_ciclos_view import build_alta_ciclos_view
 from app.views.modificacion_ciclos_view import build_modificacion_ciclos_view
@@ -281,6 +282,7 @@ def run_gui():
     frame_gen_root   = tb.Frame(content_area, padding=(16,10))  # mini-launcher de Generación
     frame_gen_auto   = tb.Frame(content_area, padding=(16,10))
     frame_gen_manual = tb.Frame(content_area, padding=(16,10))
+    frame_ai_generator = tb.Frame(content_area, padding=(16,10))
     frame_mod_matriz = tb.Frame(content_area, padding=(16,10))
     frame_alta_cic   = tb.Frame(content_area, padding=(16,10))
     frame_mod_cic    = tb.Frame(content_area, padding=(16,10))
@@ -335,6 +337,7 @@ def run_gui():
     build_generacion_automatica_view(app, frame_gen_auto, _bind_mousewheel)
 
     build_generacion_manual_view(app, frame_gen_manual, _bind_mousewheel)
+    build_generar_dde_hu_view(app, frame_ai_generator, controller.cards, Messagebox, _bind_mousewheel)
     build_modificacion_matriz_view(frame_mod_matriz)
     build_alta_ciclos_view(frame_alta_cic)
     build_modificacion_ciclos_view(frame_mod_cic)
@@ -351,6 +354,7 @@ def run_gui():
     _cards_grid(frame_launcher, [
         ("Generación Automática", "Matrices por lote",               "⚙️", lambda: go_section("GEN_AUTO", from_launcher=True)),
         ("Generación Manual",     "Genera una matriz puntual",       "✍️", lambda: go_section("GEN_MANUAL", from_launcher=True)),
+        ("Generar DDE/HU",        "Documentos con IA",               "🤖", lambda: go_section("AI_GENERATOR", from_launcher=True)),
         ("Modificación de Matriz","Busca y edita matrices",          "📝", lambda: go_section("MOD_MATRIZ", from_launcher=True)),
         ("Alta de Ciclos",        "Crea ciclos nuevos",              "➕", lambda: go_section("ALTA_CICLOS", from_launcher=True)),
         ("Modificación de Ciclos","Actualiza ciclos existentes",     "✏️", lambda: go_section("MOD_CICLOS", from_launcher=True)),
@@ -375,6 +379,7 @@ def run_gui():
     tb.Separator(sidebar, bootstyle=SECONDARY).pack(fill=X, pady=8)
     _nav_item(sidebar, "⚙️", "Generación Automática", "GEN_AUTO")
     _nav_item(sidebar, "✍️", "Generación Manual",     "GEN_MANUAL")
+    _nav_item(sidebar, "🤖", "Generar DDE/HU",        "AI_GENERATOR")
     tb.Separator(sidebar, bootstyle=SECONDARY).pack(fill=X, pady=8)
     _nav_item(sidebar, "📝", "Modificación de Matriz", "MOD_MATRIZ")
     _nav_item(sidebar, "➕", "Alta de Ciclos",          "ALTA_CICLOS")
@@ -387,6 +392,7 @@ def run_gui():
         "GEN_ROOT": frame_gen_root,
         "GEN_AUTO": frame_gen_auto,
         "GEN_MANUAL": frame_gen_manual,
+        "AI_GENERATOR": frame_ai_generator,
         "MOD_MATRIZ": frame_mod_matriz,
         "ALTA_CICLOS": frame_alta_cic,
         "MOD_CICLOS": frame_mod_cic,

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -196,6 +196,45 @@ CREATE TABLE dbo.card_scripts (
     CONSTRAINT fk_card_scripts_card FOREIGN KEY (card_id) REFERENCES dbo.cards(id) ON DELETE CASCADE
 );
 
+CREATE TABLE dbo.cards_ai_inputs (
+    input_id BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    card_id BIGINT NOT NULL,
+    tipo VARCHAR(20) NOT NULL,
+    analisis_desc_problema NVARCHAR(MAX) NULL,
+    analisis_revision_sistema NVARCHAR(MAX) NULL,
+    analisis_datos NVARCHAR(MAX) NULL,
+    analisis_comp_reglas NVARCHAR(MAX) NULL,
+    reco_investigacion NVARCHAR(MAX) NULL,
+    reco_solucion_temporal NVARCHAR(MAX) NULL,
+    reco_impl_mejoras NVARCHAR(MAX) NULL,
+    reco_com_stakeholders NVARCHAR(MAX) NULL,
+    reco_documentacion NVARCHAR(MAX) NULL,
+    completeness_pct TINYINT NOT NULL DEFAULT (0),
+    is_draft BIT NOT NULL DEFAULT (1),
+    created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT fk_cards_ai_inputs_card FOREIGN KEY (card_id) REFERENCES dbo.cards(id)
+);
+
+CREATE INDEX ix_cards_ai_inputs_card_id
+    ON dbo.cards_ai_inputs (card_id, updated_at DESC, input_id DESC);
+
+CREATE TABLE dbo.cards_ai_outputs (
+    output_id BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+    card_id BIGINT NOT NULL,
+    input_id BIGINT NULL,
+    llm_id VARCHAR(100) NULL,
+    llm_model VARCHAR(100) NULL,
+    llm_usage_json NVARCHAR(MAX) NULL,
+    content_json NVARCHAR(MAX) NOT NULL,
+    created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT fk_cards_ai_outputs_card FOREIGN KEY (card_id) REFERENCES dbo.cards(id),
+    CONSTRAINT fk_cards_ai_outputs_input FOREIGN KEY (input_id) REFERENCES dbo.cards_ai_inputs(input_id)
+);
+
+CREATE INDEX ix_cards_ai_outputs_card_id
+    ON dbo.cards_ai_outputs (card_id, created_at DESC, output_id DESC);
+
 CREATE TABLE dbo.catalog_companies (
     id INT IDENTITY(1,1) PRIMARY KEY,
     name NVARCHAR(255) NOT NULL UNIQUE,

--- a/tests/test_card_ai_service.py
+++ b/tests/test_card_ai_service.py
@@ -1,0 +1,176 @@
+"""Unit tests for the card AI service workflow."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pytest
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.dtos.card_ai_dto import (
+    CardAIInputPayload,
+    CardAIInputRecord,
+    CardAIOutputRecord,
+    CardSummary,
+    LLMGenerationResponse,
+)
+from app.services.card_ai_service import CardAIService, CardAIServiceError
+
+
+class FakeCardsDAO:
+    """In-memory implementation that mimics the cards DAO."""
+
+    def __init__(self) -> None:
+        self.card = CardSummary(1, "Card title", "INCIDENCIA", "pending", datetime.now(timezone.utc))
+
+    def listCards(self, filters: Optional[CardFilters] = None, limit: int = 250) -> List[CardSummary]:
+        return [self.card]
+
+    def fetchCard(self, card_id: int) -> Optional[CardSummary]:
+        if card_id == self.card.cardId:
+            return self.card
+        return None
+
+
+class FakeInputDAO:
+    """In-memory storage that emulates card input persistence."""
+
+    def __init__(self) -> None:
+        self.records: Dict[int, CardAIInputRecord] = {}
+        self.next_id = 1
+
+    def insertInput(self, record: CardAIInputRecord) -> int:
+        identifier = self.next_id
+        self.next_id += 1
+        stored = replace(record, inputId=identifier, createdAt=datetime.now(timezone.utc), updatedAt=datetime.now(timezone.utc))
+        self.records[identifier] = stored
+        return identifier
+
+    def fetchById(self, input_id: int) -> Optional[CardAIInputRecord]:
+        return self.records.get(input_id)
+
+    def fetchLatestForCard(self, card_id: int) -> Optional[CardAIInputRecord]:
+        for record in reversed(list(self.records.values())):
+            if record.cardId == card_id:
+                return record
+        return None
+
+    def updateDraftFlag(self, input_id: int, is_draft: bool) -> None:
+        record = self.records.get(input_id)
+        if record:
+            self.records[input_id] = replace(record, isDraft=is_draft, updatedAt=datetime.now(timezone.utc))
+
+
+class FakeOutputDAO:
+    """In-memory storage that emulates card output persistence."""
+
+    def __init__(self) -> None:
+        self.records: Dict[int, CardAIOutputRecord] = {}
+        self.next_id = 1
+
+    def insertOutput(self, record: CardAIOutputRecord) -> int:
+        identifier = self.next_id
+        self.next_id += 1
+        stored = replace(record, outputId=identifier, createdAt=datetime.now(timezone.utc))
+        self.records[identifier] = stored
+        return identifier
+
+    def fetchById(self, output_id: int) -> Optional[CardAIOutputRecord]:
+        return self.records.get(output_id)
+
+    def listOutputsForCard(self, card_id: int, limit: int = 20) -> List[CardAIOutputRecord]:
+        return [record for record in self.records.values() if record.cardId == card_id][:limit]
+
+
+class FakeLLMClient:
+    """Capture prompts and return predictable responses for tests."""
+
+    def __init__(self) -> None:
+        self.last_prompt: Optional[str] = None
+
+    def generateJson(self, prompt: str) -> LLMGenerationResponse:
+        self.last_prompt = prompt
+        return LLMGenerationResponse(
+            llmId="chat-123",
+            model="fake-model",
+            usage={"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            content={"titulo": "Documento", "descripcion": "Contenido generado"},
+        )
+
+
+def _build_payload(card_id: int = 1) -> CardAIInputPayload:
+    """Helper to create a sample payload with partial data."""
+
+    return CardAIInputPayload(
+        cardId=card_id,
+        tipo="INCIDENCIA",
+        analisisDescProblema="Detalle",
+        analisisRevisionSistema="Revisión",
+        analisisDatos="Datos",
+        analisisCompReglas="Reglas",
+        recoInvestigacion="Investigación",
+        recoSolucionTemporal="Temporal",
+        recoImplMejoras="Mejoras",
+        recoComStakeholders="Stakeholders",
+        recoDocumentacion="Documentación",
+    )
+
+
+def test_calculate_completeness_counts_filled_fields() -> None:
+    """Verify that the completeness percentage reflects filled fields."""
+
+    service = CardAIService(FakeCardsDAO(), FakeInputDAO(), FakeOutputDAO(), FakeLLMClient())
+    payload = _build_payload()
+    pct = service.calculateCompleteness(payload)
+    assert pct == 100
+
+    partial_payload = replace(payload, analisisDatos="", recoDocumentacion="")
+    pct_partial = service.calculateCompleteness(partial_payload)
+    assert pct_partial == pytest.approx(round(7 / 9 * 100))
+
+
+def test_generate_document_persists_records_and_calls_llm() -> None:
+    """The service should store inputs and outputs and return the result."""
+
+    fake_llm = FakeLLMClient()
+    service = CardAIService(FakeCardsDAO(), FakeInputDAO(), FakeOutputDAO(), fake_llm)
+    payload = _build_payload()
+
+    result = service.generateDocument(payload)
+
+    assert result.inputRecord.inputId is not None
+    assert result.outputRecord.outputId is not None
+    assert result.outputRecord.content["titulo"] == "Documento"
+    assert "### Análisis" in (fake_llm.last_prompt or "")
+
+
+def test_regenerate_from_input_uses_existing_payload() -> None:
+    """Regeneration should reuse stored inputs and create a new output."""
+
+    fake_llm = FakeLLMClient()
+    inputs = FakeInputDAO()
+    outputs = FakeOutputDAO()
+    service = CardAIService(FakeCardsDAO(), inputs, outputs, fake_llm)
+
+    draft = service.saveDraft(_build_payload())
+    assert draft.inputId is not None
+
+    result = service.regenerateFromInput(draft.inputId or 0)
+    assert result.outputRecord.outputId is not None
+    assert outputs.records
+
+
+def test_generate_document_raises_error_for_unknown_card() -> None:
+    """Attempting to generate a document for an unknown card fails."""
+
+    fake_llm = FakeLLMClient()
+    service = CardAIService(FakeCardsDAO(), FakeInputDAO(), FakeOutputDAO(), fake_llm)
+    payload = _build_payload(card_id=999)
+
+    with pytest.raises(CardAIServiceError):
+        service.generateDocument(payload)


### PR DESCRIPTION
## Summary
- add cards AI DTOs, DAOs, service and controller along with a configurable local LLM client
- build the Generar DDE/HU view with card filters, capture form, history preview and export tools
- update navigation, database schema documentation, changelog and add unit tests for the new service

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6901479bd748832cadff329a2d9b5162