### PR TITLE
feat: add AI-assisted DDE generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.8.0] - 2024-06-02
 ### Added
-- Vista dedicada para generar documentos DDE/HU asistidos por IA con filtros, buscador en tiempo real y barra de progreso de completitud. 
+- Vista dedicada para generar documentos DDE/HU asistidos por IA con filtros, buscador en tiempo real y barra de progreso de completitud.
 - Controlador, servicio y DAOs especializados para consultar tarjetas, guardar capturas y almacenar respuestas del LLM.
 - Exportación de resultados en formatos JSON, Markdown y DOCX junto con historial de ejecuciones previas.
 - Pruebas unitarias del servicio de IA utilizando dobles de prueba para los DAOs y el cliente HTTP.
@@ -10,6 +10,9 @@
 ### Changed
 - El menú principal incorpora acceso directo al nuevo generador de DDE/HU y actualiza la navegación lateral correspondiente.
 - La documentación del esquema de base de datos describe las tablas `dbo.cards_ai_inputs` y `dbo.cards_ai_outputs` con sus índices.
+
+### Fixed
+- Se corrige un `NameError` en la vista del generador DDE/HU al mostrar mensajes de error desde hilos en segundo plano.
 
 ## [0.7.1] - 2024-06-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.8.0] - 2024-06-02
+### Added
+- Vista dedicada para generar documentos DDE/HU asistidos por IA con filtros, buscador en tiempo real y barra de progreso de completitud. 
+- Controlador, servicio y DAOs especializados para consultar tarjetas, guardar capturas y almacenar respuestas del LLM.
+- Exportación de resultados en formatos JSON, Markdown y DOCX junto con historial de ejecuciones previas.
+- Pruebas unitarias del servicio de IA utilizando dobles de prueba para los DAOs y el cliente HTTP.
+
+### Changed
+- El menú principal incorpora acceso directo al nuevo generador de DDE/HU y actualiza la navegación lateral correspondiente.
+- La documentación del esquema de base de datos describe las tablas `dbo.cards_ai_inputs` y `dbo.cards_ai_outputs` con sus índices.
+
 ## [0.7.1] - 2024-06-01
 ### Added
 - Controladores especializados para autenticación, historial, navegador, nomenclatura y sesiones que encapsulan la coordinación con sus servicios correspondientes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - Se corrige un `NameError` en la vista del generador DDE/HU al mostrar mensajes de error desde hilos en segundo plano.
+- Se evita un `TclError` al restaurar los botones de acciones cuando la ventana de captura se cierra durante una generación.
 
 ## [0.7.1] - 2024-06-01
 ### Added

--- a/app/config/ai_config.py
+++ b/app/config/ai_config.py
@@ -1,0 +1,75 @@
+"""Configuration helper for the local language model endpoint."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Mapping, MutableMapping, Optional
+
+
+@dataclass
+class AIConfiguration:
+    """Resolve connection parameters for the AI generation endpoint."""
+
+    DEFAULT_URL: str = "http://127.0.0.1:1234/v1/chat/completions"
+    DEFAULT_MODEL: str = "qwen/qwen2.5-vl-7b"
+    DEFAULT_TEMPERATURE: float = 0.35
+    DEFAULT_TOP_P: float = 0.9
+    DEFAULT_MAX_TOKENS: int = 3000
+
+    def __init__(self, environ: Optional[Mapping[str, str]] = None) -> None:
+        """Persist the environment mapping used to read configuration values."""
+
+        self._environ: MutableMapping[str, str] = (
+            dict(environ) if environ is not None else dict(os.environ)
+        )
+
+    def get_api_url(self) -> str:
+        """Return the base URL for the chat completions endpoint."""
+
+        return self._environ.get("LM_URL", self.DEFAULT_URL).strip() or self.DEFAULT_URL
+
+    def get_model_name(self) -> str:
+        """Return the model identifier provided to the LLM endpoint."""
+
+        return self._environ.get("LM_MODEL", self.DEFAULT_MODEL).strip() or self.DEFAULT_MODEL
+
+    def get_api_key(self) -> Optional[str]:
+        """Expose the optional API key forwarded as bearer token."""
+
+        token = self._environ.get("LM_API_KEY", "").strip()
+        return token or None
+
+    def get_temperature(self) -> float:
+        """Return the sampling temperature configured for generations."""
+
+        raw = self._environ.get("LM_TEMPERATURE")
+        if raw is None:
+            return self.DEFAULT_TEMPERATURE
+        try:
+            return float(raw)
+        except ValueError:
+            return self.DEFAULT_TEMPERATURE
+
+    def get_top_p(self) -> float:
+        """Return the nucleus sampling value used when contacting the LLM."""
+
+        raw = self._environ.get("LM_TOP_P")
+        if raw is None:
+            return self.DEFAULT_TOP_P
+        try:
+            return float(raw)
+        except ValueError:
+            return self.DEFAULT_TOP_P
+
+    def get_max_tokens(self) -> int:
+        """Return the maximum amount of tokens allowed per completion."""
+
+        raw = self._environ.get("LM_MAX_TOKENS")
+        if raw is None:
+            return self.DEFAULT_MAX_TOKENS
+        try:
+            return int(raw)
+        except ValueError:
+            return self.DEFAULT_MAX_TOKENS
+

--- a/app/controllers/card_ai_controller.py
+++ b/app/controllers/card_ai_controller.py
@@ -1,0 +1,82 @@
+"""Controller orchestrating the cards AI assistant interactions."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from app.dtos.card_ai_dto import (
+    CardAIHistoryEntryDTO,
+    CardAIInputDTO,
+    CardAIGenerationResultDTO,
+    CardDTO,
+    CardFiltersDTO,
+    card_ai_request_from_dict,
+)
+from app.services.card_ai_service import CardAIService, CardAIServiceError
+
+
+class CardAIController:
+    """Expose a simplified API tailored for the Tkinter views."""
+
+    def __init__(self, service: CardAIService) -> None:
+        """Store the service that performs the heavy lifting."""
+
+        self._service = service
+
+    def list_cards(self, filters: Dict[str, object]) -> List[CardDTO]:
+        """Return cards matching the filters provided by the view."""
+
+        dto = CardFiltersDTO(
+            cardType=str(filters.get("tipo")) if filters.get("tipo") else None,
+            status=str(filters.get("status")) if filters.get("status") else None,
+            startDate=filters.get("fechaInicio"),
+            endDate=filters.get("fechaFin"),
+            searchText=str(filters.get("busqueda")) if filters.get("busqueda") else None,
+        )
+        try:
+            return self._service.list_cards(dto)
+        except CardAIServiceError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+    def save_draft(self, payload: Dict[str, object]) -> CardAIInputDTO:
+        """Persist a new draft entry for the selected card."""
+
+        dto = card_ai_request_from_dict(payload)
+        try:
+            return self._service.save_draft(dto)
+        except CardAIServiceError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+    def generate_document(self, payload: Dict[str, object]) -> CardAIGenerationResultDTO:
+        """Trigger a new generation and persist the resulting document."""
+
+        dto = card_ai_request_from_dict(payload)
+        try:
+            return self._service.generate_document(dto)
+        except CardAIServiceError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+    def regenerate(self, input_id: int) -> CardAIGenerationResultDTO:
+        """Trigger a new generation using a stored input identifier."""
+
+        try:
+            return self._service.regenerate_from_input(input_id)
+        except CardAIServiceError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+    def list_inputs(self, card_id: int, limit: int = 50) -> List[CardAIInputDTO]:
+        """Return the captured inputs for a card."""
+
+        try:
+            return self._service.list_inputs(card_id, limit=limit)
+        except CardAIServiceError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+    def list_history(self, card_id: int, limit: int = 20) -> List[CardAIHistoryEntryDTO]:
+        """Return the output history for a card."""
+
+        try:
+            return self._service.list_history(card_id, limit=limit)
+        except CardAIServiceError as exc:
+            raise RuntimeError(str(exc)) from exc
+

--- a/app/controllers/main_controller.py
+++ b/app/controllers/main_controller.py
@@ -9,16 +9,21 @@ from app.config.storage_paths import (
 )
 from app.controllers.auth_controller import AuthenticationController
 from app.controllers.browser_controller import BrowserController
+from app.controllers.card_ai_controller import CardAIController
 from app.controllers.history_controller import HistoryController
 from app.controllers.naming_controller import NamingController
 from app.controllers.session_controller import SessionController
 from app.daos.database import DatabaseConnector
 from app.daos.evidence_dao import SessionEvidenceDAO
+from app.daos.card_ai_input_dao import CardAIInputDAO
+from app.daos.card_ai_output_dao import CardAIOutputDAO
+from app.daos.card_dao import CardDAO
 from app.daos.history_dao import HistoryDAO
 from app.daos.session_dao import SessionDAO
 from app.daos.session_pause_dao import SessionPauseDAO
 from app.daos.user_dao import UserDAO
 from app.services.auth_service import AuthService
+from app.services.card_ai_service import CardAIService
 from app.services.browser_service import BrowserService
 from app.services.history_service import HistoryService
 from app.services.naming_service import NamingService
@@ -67,3 +72,11 @@ class MainController:
             self.SESSIONS_DIR,
             self.EVIDENCE_DIR,
         )
+
+        cards_connector = DatabaseConnector().connection_factory()
+        card_service = CardAIService(
+            CardDAO(cards_connector),
+            CardAIInputDAO(cards_connector),
+            CardAIOutputDAO(cards_connector),
+        )
+        self.cardsAI = CardAIController(card_service)

--- a/app/daos/card_ai_input_dao.py
+++ b/app/daos/card_ai_input_dao.py
@@ -1,0 +1,258 @@
+"""DAO responsible for persisting captured AI inputs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Iterable, List, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - only used for typing hints
+    import pymssql
+
+from app.daos.database import DatabaseConnectorError
+from app.dtos.card_ai_dto import CardAIInputDTO
+
+
+class CardAIInputDAOError(RuntimeError):
+    """Raised when input prompts cannot be stored or retrieved."""
+
+
+class CardAIInputDAO:
+    """Provide CRUD helpers for ``dbo.cards_ai_inputs``."""
+
+    def __init__(self, connection_factory: Callable[[], "pymssql.Connection"]) -> None:
+        """Store the callable that opens SQL Server connections."""
+
+        self._connection_factory = connection_factory
+        self._schema_ready = False
+
+    def _ensure_schema(self) -> None:
+        """Create the inputs table the first time it is required."""
+
+        if self._schema_ready:
+            return
+
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise CardAIInputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.tables t
+                    INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+                    WHERE t.name = 'cards_ai_inputs' AND s.name = 'dbo'
+                )
+                BEGIN
+                    CREATE TABLE dbo.cards_ai_inputs (
+                        input_id BIGINT IDENTITY(1,1) PRIMARY KEY,
+                        card_id BIGINT NOT NULL,
+                        tipo VARCHAR(20) NOT NULL,
+                        descripcion NVARCHAR(MAX) NULL,
+                        analisis NVARCHAR(MAX) NULL,
+                        recomendaciones NVARCHAR(MAX) NULL,
+                        cosas_prevenir NVARCHAR(MAX) NULL,
+                        info_adicional NVARCHAR(MAX) NULL,
+                        completeness_pct TINYINT NOT NULL DEFAULT(0),
+                        is_draft BIT NOT NULL DEFAULT(1),
+                        created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+                        updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME()
+                    );
+                    CREATE INDEX ix_cards_ai_inputs_card_id
+                        ON dbo.cards_ai_inputs (card_id DESC, input_id DESC);
+                END
+                """
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise CardAIInputDAOError("No fue posible preparar la tabla de entradas AI.") from exc
+        finally:
+            connection.close()
+
+        self._schema_ready = True
+
+    @staticmethod
+    def _row_to_dto(row: Tuple) -> CardAIInputDTO:
+        """Convert a database row into a DTO instance."""
+
+        created_at = row[10]
+        updated_at = row[11]
+        if not isinstance(created_at, datetime):
+            created_at = datetime.fromisoformat(str(created_at))
+        if not isinstance(updated_at, datetime):
+            updated_at = datetime.fromisoformat(str(updated_at))
+        return CardAIInputDTO(
+            inputId=int(row[0]),
+            cardId=int(row[1]),
+            tipo=str(row[2] or ""),
+            descripcion=row[3],
+            analisis=row[4],
+            recomendaciones=row[5],
+            cosasPrevenir=row[6],
+            infoAdicional=row[7],
+            completenessPct=int(row[8] or 0),
+            isDraft=bool(row[9]),
+            createdAt=created_at,
+            updatedAt=updated_at,
+        )
+
+    def create_input(
+        self,
+        card_id: int,
+        tipo: str,
+        descripcion: Optional[str],
+        analisis: Optional[str],
+        recomendaciones: Optional[str],
+        cosas_prevenir: Optional[str],
+        info_adicional: Optional[str],
+        completeness_pct: int,
+        is_draft: bool,
+    ) -> CardAIInputDTO:
+        """Insert a new prompt input and return the persisted DTO."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise CardAIInputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "INSERT INTO dbo.cards_ai_inputs "
+                    "(card_id, tipo, descripcion, analisis, recomendaciones, cosas_prevenir, info_adicional, completeness_pct, is_draft) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s);"
+                    "SELECT input_id, card_id, tipo, descripcion, analisis, recomendaciones, cosas_prevenir, info_adicional, completeness_pct, is_draft, created_at, updated_at "
+                    "FROM dbo.cards_ai_inputs WHERE input_id = SCOPE_IDENTITY();"
+                ),
+                (
+                    card_id,
+                    tipo,
+                    descripcion,
+                    analisis,
+                    recomendaciones,
+                    cosas_prevenir,
+                    info_adicional,
+                    completeness_pct,
+                    1 if is_draft else 0,
+                ),
+            )
+            row = cursor.fetchone()
+            connection.commit()
+        except Exception as exc:  # pragma: no cover
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise CardAIInputDAOError("No fue posible guardar la captura de la tarjeta.") from exc
+
+        connection.close()
+        return self._row_to_dto(row)
+
+    def list_by_card(self, card_id: int, limit: int = 50) -> List[CardAIInputDTO]:
+        """Return the most recent inputs associated with a card."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise CardAIInputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "SELECT TOP (%s) input_id, card_id, tipo, descripcion, analisis, recomendaciones,"
+                    " cosas_prevenir, info_adicional, completeness_pct, is_draft, created_at, updated_at "
+                    "FROM dbo.cards_ai_inputs WHERE card_id = %s ORDER BY created_at DESC, input_id DESC"
+                ),
+                (limit, card_id),
+            )
+            rows: Iterable[Tuple] = cursor.fetchall()
+        except Exception as exc:  # pragma: no cover
+            connection.close()
+            raise CardAIInputDAOError("No fue posible consultar las capturas de la tarjeta.") from exc
+
+        connection.close()
+        results: List[CardAIInputDTO] = []
+        for row in rows:
+            created_at = row[10]
+            updated_at = row[11]
+            if not isinstance(created_at, datetime):
+                created_at = datetime.fromisoformat(str(created_at))
+            if not isinstance(updated_at, datetime):
+                updated_at = datetime.fromisoformat(str(updated_at))
+            results.append(
+                CardAIInputDTO(
+                    inputId=int(row[0]),
+                    cardId=int(row[1]),
+                    tipo=str(row[2] or ""),
+                    descripcion=row[3],
+                    analisis=row[4],
+                    recomendaciones=row[5],
+                    cosasPrevenir=row[6],
+                    infoAdicional=row[7],
+                    completenessPct=int(row[8] or 0),
+                    isDraft=bool(row[9]),
+                    createdAt=created_at,
+                    updatedAt=updated_at,
+                )
+            )
+        return results
+
+    def get_input(self, input_id: int) -> Optional[CardAIInputDTO]:
+        """Return an input DTO by its identifier."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise CardAIInputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                "SELECT input_id, card_id, tipo, descripcion, analisis, recomendaciones,"
+                " cosas_prevenir, info_adicional, completeness_pct, is_draft, created_at, updated_at"
+                " FROM dbo.cards_ai_inputs WHERE input_id = %s",
+                (input_id,),
+            )
+            row = cursor.fetchone()
+        except Exception as exc:  # pragma: no cover
+            connection.close()
+            raise CardAIInputDAOError("No fue posible consultar la captura solicitada.") from exc
+
+        connection.close()
+        if not row:
+            return None
+
+        created_at = row[10]
+        updated_at = row[11]
+        if not isinstance(created_at, datetime):
+            created_at = datetime.fromisoformat(str(created_at))
+        if not isinstance(updated_at, datetime):
+            updated_at = datetime.fromisoformat(str(updated_at))
+        return CardAIInputDTO(
+            inputId=int(row[0]),
+            cardId=int(row[1]),
+            tipo=str(row[2] or ""),
+            descripcion=row[3],
+            analisis=row[4],
+            recomendaciones=row[5],
+            cosasPrevenir=row[6],
+            infoAdicional=row[7],
+            completenessPct=int(row[8] or 0),
+            isDraft=bool(row[9]),
+            createdAt=created_at,
+            updatedAt=updated_at,
+        )
+

--- a/app/daos/card_ai_output_dao.py
+++ b/app/daos/card_ai_output_dao.py
@@ -1,0 +1,177 @@
+"""DAO responsible for persisting LLM outputs for cards."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Iterable, List, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - only used for typing hints
+    import pymssql
+
+from app.daos.database import DatabaseConnectorError
+from app.dtos.card_ai_dto import CardAIOutputDTO
+
+
+class CardAIOutputDAOError(RuntimeError):
+    """Raised when LLM outputs cannot be stored or retrieved."""
+
+
+class CardAIOutputDAO:
+    """Provide CRUD helpers for ``dbo.cards_ai_outputs``."""
+
+    def __init__(self, connection_factory: Callable[[], "pymssql.Connection"]) -> None:
+        """Store the callable that opens SQL Server connections."""
+
+        self._connection_factory = connection_factory
+        self._schema_ready = False
+
+    def _ensure_schema(self) -> None:
+        """Create the outputs table the first time it is required."""
+
+        if self._schema_ready:
+            return
+
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise CardAIOutputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1 FROM sys.tables t
+                    INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+                    WHERE t.name = 'cards_ai_outputs' AND s.name = 'dbo'
+                )
+                BEGIN
+                    CREATE TABLE dbo.cards_ai_outputs (
+                        output_id BIGINT IDENTITY(1,1) PRIMARY KEY,
+                        card_id BIGINT NOT NULL,
+                        input_id BIGINT NULL,
+                        llm_id VARCHAR(100) NULL,
+                        llm_model VARCHAR(100) NULL,
+                        llm_usage_json NVARCHAR(MAX) NULL,
+                        content_json NVARCHAR(MAX) NOT NULL,
+                        created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME()
+                    );
+                    CREATE INDEX ix_cards_ai_outputs_card_id
+                        ON dbo.cards_ai_outputs (card_id DESC, output_id DESC);
+                END
+                """
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise CardAIOutputDAOError("No fue posible preparar la tabla de resultados AI.") from exc
+        finally:
+            connection.close()
+
+        self._schema_ready = True
+
+    def create_output(
+        self,
+        card_id: int,
+        input_id: Optional[int],
+        llm_id: Optional[str],
+        llm_model: Optional[str],
+        llm_usage: Optional[dict],
+        content: dict,
+    ) -> CardAIOutputDTO:
+        """Insert a new output document and return the stored DTO."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise CardAIOutputDAOError(str(exc)) from exc
+
+        usage_json = json.dumps(llm_usage or {})
+        content_json = json.dumps(content)
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "INSERT INTO dbo.cards_ai_outputs "
+                    "(card_id, input_id, llm_id, llm_model, llm_usage_json, content_json) "
+                    "VALUES (%s, %s, %s, %s, %s, %s);"
+                    "SELECT output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, created_at "
+                    "FROM dbo.cards_ai_outputs WHERE output_id = SCOPE_IDENTITY();"
+                ),
+                (card_id, input_id, llm_id, llm_model, usage_json, content_json),
+            )
+            row = cursor.fetchone()
+            connection.commit()
+        except Exception as exc:  # pragma: no cover
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise CardAIOutputDAOError("No fue posible guardar el resultado generado.") from exc
+
+        connection.close()
+        created_at = row[7]
+        if not isinstance(created_at, datetime):
+            created_at = datetime.fromisoformat(str(created_at))
+        return CardAIOutputDTO(
+            outputId=int(row[0]),
+            cardId=int(row[1]),
+            inputId=int(row[2]) if row[2] is not None else None,
+            llmId=row[3],
+            llmModel=row[4],
+            llmUsage=json.loads(row[5] or "{}"),
+            content=json.loads(row[6] or "{}"),
+            createdAt=created_at,
+        )
+
+    def list_by_card(self, card_id: int, limit: int = 50) -> List[CardAIOutputDTO]:
+        """Return the most recent outputs stored for a card."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise CardAIOutputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "SELECT TOP (%s) output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, created_at "
+                    "FROM dbo.cards_ai_outputs WHERE card_id = %s ORDER BY created_at DESC, output_id DESC"
+                ),
+                (limit, card_id),
+            )
+            rows: Iterable[Tuple] = cursor.fetchall()
+        except Exception as exc:  # pragma: no cover
+            connection.close()
+            raise CardAIOutputDAOError("No fue posible consultar los resultados generados.") from exc
+
+        connection.close()
+        outputs: List[CardAIOutputDTO] = []
+        for row in rows:
+            created_at = row[7]
+            if not isinstance(created_at, datetime):
+                created_at = datetime.fromisoformat(str(created_at))
+            outputs.append(
+                CardAIOutputDTO(
+                    outputId=int(row[0]),
+                    cardId=int(row[1]),
+                    inputId=int(row[2]) if row[2] is not None else None,
+                    llmId=row[3],
+                    llmModel=row[4],
+                    llmUsage=json.loads(row[5] or "{}"),
+                    content=json.loads(row[6] or "{}"),
+                    createdAt=created_at,
+                )
+            )
+        return outputs
+

--- a/app/daos/card_dao.py
+++ b/app/daos/card_dao.py
@@ -1,0 +1,124 @@
+"""DAO to read Branch History cards from SQL Server."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Iterable, List, Optional, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - only used for typing hints
+    import pymssql
+
+from app.daos.database import DatabaseConnectorError
+from app.dtos.card_ai_dto import CardDTO, CardFiltersDTO
+
+
+class CardDAOError(RuntimeError):
+    """Raised when the card catalog cannot be read from SQL Server."""
+
+
+class CardDAO:
+    """Provide read access to ``dbo.cards`` required by the AI assistant."""
+
+    def __init__(self, connection_factory: Callable[[], "pymssql.Connection"]) -> None:
+        """Store the callable that creates new database connections."""
+
+        self._connection_factory = connection_factory
+
+    def _normalize_epoch(self, value: Optional[int]) -> Optional[datetime]:
+        """Convert epoch seconds into timezone-aware datetimes when possible."""
+
+        if value is None:
+            return None
+        try:
+            return datetime.fromtimestamp(int(value))
+        except (ValueError, OverflowError, OSError):  # pragma: no cover - depende de datos
+            return None
+
+    def list_cards(self, filters: CardFiltersDTO, limit: int = 200) -> List[CardDTO]:
+        """Return the cards matching the provided filters sorted by recency."""
+
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover - depende del entorno
+            raise CardDAOError(str(exc)) from exc
+
+        conditions: List[str] = []
+        params: List[object] = []
+
+        if filters.cardType:
+            conditions.append("COALESCE(group_name, '') = %s")
+            params.append(filters.cardType)
+        if filters.status:
+            conditions.append("COALESCE(status, '') = %s")
+            params.append(filters.status)
+        if filters.startDate:
+            conditions.append("created_at >= %s")
+            params.append(int(filters.startDate.timestamp()))
+        if filters.endDate:
+            conditions.append("created_at <= %s")
+            params.append(int(filters.endDate.timestamp()))
+        if filters.searchText:
+            conditions.append("(title LIKE %s OR COALESCE(description,'') LIKE %s OR COALESCE(ticket_id,'') LIKE %s)")
+            like_token = f"%{filters.searchText}%"
+            params.extend([like_token, like_token, like_token])
+
+        where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
+
+        sql = (
+            "SELECT TOP (%s) id, title, COALESCE(group_name, ''), COALESCE(status,''),"
+            " created_at, updated_at, COALESCE(ticket_id,''), COALESCE(branch_key,'')"
+            " FROM dbo.cards"
+            f"{where_clause}"
+            " ORDER BY COALESCE(updated_at, created_at) DESC"
+        )
+
+        params = [limit] + params
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(sql, params)
+            rows: Iterable[Tuple] = cursor.fetchall()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            connection.close()
+            raise CardDAOError("No fue posible leer las tarjetas.") from exc
+
+        connection.close()
+        cards: List[CardDTO] = []
+        for row in rows:
+            created_at = self._normalize_epoch(row[4])
+            updated_at = self._normalize_epoch(row[5])
+            cards.append(
+                CardDTO(
+                    cardId=int(row[0]),
+                    title=str(row[1] or ""),
+                    cardType=str(row[2] or ""),
+                    status=str(row[3] or ""),
+                    createdAt=created_at,
+                    updatedAt=updated_at,
+                    ticketId=str(row[6] or ""),
+                    branchKey=str(row[7] or ""),
+                )
+            )
+        return cards
+
+    def get_card_title(self, card_id: int) -> str:
+        """Return the title of the card or raise when not found."""
+
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise CardDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute("SELECT title FROM dbo.cards WHERE id = %s", (card_id,))
+            row = cursor.fetchone()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            connection.close()
+            raise CardDAOError("No fue posible leer la tarjeta solicitada.") from exc
+
+        connection.close()
+        if not row:
+            raise CardDAOError("La tarjeta solicitada no existe.")
+        return str(row[0] or "")
+

--- a/app/dtos/card_ai_dto.py
+++ b/app/dtos/card_ai_dto.py
@@ -1,0 +1,111 @@
+"""DTOs used by the card AI assistant workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class CardDTO:
+    """Represent a Jira/Branch History card available for AI generation."""
+
+    cardId: int
+    title: str
+    cardType: str
+    status: str
+    createdAt: Optional[datetime]
+    updatedAt: Optional[datetime]
+    ticketId: str
+    branchKey: str
+
+
+@dataclass
+class CardFiltersDTO:
+    """Encapsulate filter values applied to the cards grid."""
+
+    cardType: Optional[str] = None
+    status: Optional[str] = None
+    startDate: Optional[datetime] = None
+    endDate: Optional[datetime] = None
+    searchText: Optional[str] = None
+
+
+@dataclass
+class CardAIInputDTO:
+    """Represent a captured prompt for a particular card."""
+
+    inputId: int
+    cardId: int
+    tipo: str
+    descripcion: Optional[str]
+    analisis: Optional[str]
+    recomendaciones: Optional[str]
+    cosasPrevenir: Optional[str]
+    infoAdicional: Optional[str]
+    completenessPct: int
+    isDraft: bool
+    createdAt: datetime
+    updatedAt: datetime
+
+
+@dataclass
+class CardAIOutputDTO:
+    """Represent the JSON document returned by the LLM."""
+
+    outputId: int
+    cardId: int
+    inputId: Optional[int]
+    llmId: Optional[str]
+    llmModel: Optional[str]
+    llmUsage: Dict[str, Any]
+    content: Dict[str, Any]
+    createdAt: datetime
+
+
+@dataclass
+class CardAIHistoryEntryDTO:
+    """Combine input and output metadata for history listings."""
+
+    output: CardAIOutputDTO
+    input: Optional[CardAIInputDTO]
+
+
+@dataclass
+class CardAIGenerationResultDTO:
+    """Return the stored input/output pair after generation."""
+
+    input: CardAIInputDTO
+    output: CardAIOutputDTO
+    completenessPct: int
+
+
+@dataclass
+class CardAIRequestDTO:
+    """Capture the fields provided by the UI before persisting them."""
+
+    cardId: int
+    tipo: str
+    descripcion: Optional[str]
+    analisis: Optional[str]
+    recomendaciones: Optional[str]
+    cosasPrevenir: Optional[str]
+    infoAdicional: Optional[str]
+    forceSaveInputs: bool = False
+
+
+def card_ai_request_from_dict(payload: Dict[str, Any]) -> CardAIRequestDTO:
+    """Create a request DTO from a dictionary received from the view."""
+
+    return CardAIRequestDTO(
+        cardId=int(payload.get("cardId", 0)),
+        tipo=str(payload.get("tipo", "")).strip() or "INCIDENCIA",
+        descripcion=payload.get("descripcion"),
+        analisis=payload.get("analisis"),
+        recomendaciones=payload.get("recomendaciones"),
+        cosasPrevenir=payload.get("cosasPrevenir"),
+        infoAdicional=payload.get("infoAdicional"),
+        forceSaveInputs=bool(payload.get("forceSaveInputs", False)),
+    )
+

--- a/app/services/card_ai_service.py
+++ b/app/services/card_ai_service.py
@@ -1,0 +1,285 @@
+"""Business logic for generating DDE/HU documents using the local LLM."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Callable, Dict, List, Optional
+
+try:  # pragma: no cover - fallback for environments without requests installed
+    import requests
+except ModuleNotFoundError:  # pragma: no cover
+    from types import SimpleNamespace
+
+    class _RequestsFallbackError(Exception):
+        """Raised when the optional `requests` dependency is missing."""
+
+        pass
+
+    def _missing_post(*_args, **_kwargs):  # type: ignore[override]
+        raise _RequestsFallbackError("La dependencia 'requests' no está instalada.")
+
+    requests = SimpleNamespace(  # type: ignore[assignment]
+        RequestException=_RequestsFallbackError,
+        post=_missing_post,
+    )
+
+from app.config.ai_config import AIConfiguration
+from app.daos.card_ai_input_dao import CardAIInputDAO, CardAIInputDAOError
+from app.daos.card_ai_output_dao import CardAIOutputDAO, CardAIOutputDAOError
+from app.daos.card_dao import CardDAO, CardDAOError
+from app.dtos.card_ai_dto import (
+    CardAIHistoryEntryDTO,
+    CardAIInputDTO,
+    CardAIRequestDTO,
+    CardAIGenerationResultDTO,
+    CardDTO,
+    CardFiltersDTO,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class CardAIServiceError(RuntimeError):
+    """Raised when the AI assistant cannot complete an operation."""
+
+
+class CardAIService:
+    """Coordinate DAOs and the LLM endpoint to build DDE/HU documents."""
+
+    def __init__(
+        self,
+        card_dao: CardDAO,
+        input_dao: CardAIInputDAO,
+        output_dao: CardAIOutputDAO,
+        configuration: Optional[AIConfiguration] = None,
+        http_post: Optional[Callable[..., requests.Response]] = None,
+    ) -> None:
+        """Store dependencies used by the service."""
+
+        self._card_dao = card_dao
+        self._input_dao = input_dao
+        self._output_dao = output_dao
+        self._config = configuration or AIConfiguration()
+        self._http_post = http_post or requests.post
+
+    @staticmethod
+    def calculate_completeness(payload: CardAIRequestDTO) -> int:
+        """Return the completeness percentage for the provided payload."""
+
+        fields = [
+            payload.descripcion,
+            payload.analisis,
+            payload.recomendaciones,
+            payload.cosasPrevenir,
+            payload.infoAdicional,
+        ]
+        filled = sum(1 for field in fields if field and str(field).strip())
+        return round(100 * filled / len(fields)) if fields else 0
+
+    def list_cards(self, filters: CardFiltersDTO, limit: int = 200) -> List[CardDTO]:
+        """Expose the card catalog for the view layer."""
+
+        try:
+            return self._card_dao.list_cards(filters, limit=limit)
+        except CardDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+    def list_inputs(self, card_id: int, limit: int = 50) -> List[CardAIInputDTO]:
+        """Return previous inputs associated with a card."""
+
+        try:
+            return self._input_dao.list_by_card(card_id, limit=limit)
+        except CardAIInputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+    def list_history(self, card_id: int, limit: int = 20) -> List[CardAIHistoryEntryDTO]:
+        """Return combined input/output history for a card."""
+
+        try:
+            outputs = self._output_dao.list_by_card(card_id, limit=limit)
+        except CardAIOutputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        history: List[CardAIHistoryEntryDTO] = []
+        for output in outputs:
+            input_dto: Optional[CardAIInputDTO] = None
+            if output.inputId is not None:
+                try:
+                    input_dto = self._input_dao.get_input(output.inputId)
+                except CardAIInputDAOError as exc:
+                    logger.error("No fue posible recuperar la captura %s: %s", output.inputId, exc)
+            history.append(CardAIHistoryEntryDTO(output=output, input=input_dto))
+        return history
+
+    def save_draft(self, payload: CardAIRequestDTO) -> CardAIInputDTO:
+        """Persist the provided data as draft without contacting the LLM."""
+
+        completeness = self.calculate_completeness(payload)
+        try:
+            return self._input_dao.create_input(
+                payload.cardId,
+                payload.tipo,
+                payload.descripcion,
+                payload.analisis,
+                payload.recomendaciones,
+                payload.cosasPrevenir,
+                payload.infoAdicional,
+                completeness,
+                True,
+            )
+        except CardAIInputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+    def _build_user_prompt(self, tipo: str, titulo_card: str, payload: CardAIRequestDTO) -> str:
+        """Return the message sent to the LLM following the requested format."""
+
+        data = {
+            "descripcion": payload.descripcion or "",
+            "analisis": payload.analisis or "",
+            "recomendaciones": payload.recomendaciones or "",
+            "cosas_prevenir": payload.cosasPrevenir or "",
+            "info_adicional": payload.infoAdicional or "",
+        }
+        return (
+            "Eres un redactor técnico y analista de requerimientos del área de TI en Sistemas Premium.\n"
+            "Genera un documento formal en formato DDE o HU según el tipo indicado.\n\n"
+            "Datos:\n"
+            f"- Título: {titulo_card}\n"
+            f"- Descripción: {data['descripcion']}\n"
+            f"- Análisis: {data['analisis']}\n"
+            f"- Recomendaciones: {data['recomendaciones']}\n"
+            f"- Cosas a prevenir: {data['cosas_prevenir']}\n"
+            f"- Información adicional: {data['info_adicional']}\n\n"
+            "Usa este esquema JSON:\n"
+            "{\n"
+            "  \"titulo\": string,\n"
+            "  \"fecha\": string,\n"
+            "  \"hora_inicio\": string,\n"
+            "  \"hora_fin\": string,\n"
+            "  \"lugar\": \"Sistemas Premium\",\n"
+            f"  \"encabezado_tipo\": \"{tipo}\",\n"
+            "  \"descripcion\": string,\n"
+            "  \"que_necesitas\": string,\n"
+            "  \"para_que\": string,\n"
+            "  \"como_necesitas\": string,\n"
+            "  \"requerimientos_funcionales\": string[],\n"
+            "  \"requerimientos_especiales\": string[],\n"
+            "  \"criterios_aceptacion\": string[]\n"
+            "}\n"
+            "Devuelve **solo el JSON**, sin texto adicional."
+        )
+
+    def _call_llm(self, prompt: str) -> Dict[str, object]:
+        """Send the completion request to the configured LLM."""
+
+        headers = {"Content-Type": "application/json"}
+        token = self._config.get_api_key()
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        else:
+            headers["Authorization"] = "Bearer local"
+
+        payload = {
+            "model": self._config.get_model_name(),
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": self._config.get_temperature(),
+            "top_p": self._config.get_top_p(),
+            "max_tokens": self._config.get_max_tokens(),
+        }
+
+        try:
+            response = self._http_post(
+                self._config.get_api_url(),
+                headers=headers,
+                json=payload,
+                timeout=180,
+            )
+        except requests.RequestException as exc:
+            raise CardAIServiceError(f"No fue posible contactar al modelo: {exc}") from exc
+
+        if not response.ok:
+            raise CardAIServiceError(
+                f"Error del modelo {response.status_code}: {response.text.strip()[:200]}"
+            )
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise CardAIServiceError("La respuesta del modelo no es JSON válido.") from exc
+
+    def generate_document(self, payload: CardAIRequestDTO) -> CardAIGenerationResultDTO:
+        """Persist the prompt, invoke the LLM and store the resulting JSON."""
+
+        try:
+            titulo = self._card_dao.get_card_title(payload.cardId)
+        except CardDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        completeness = self.calculate_completeness(payload)
+        try:
+            input_dto = self._input_dao.create_input(
+                payload.cardId,
+                payload.tipo,
+                payload.descripcion,
+                payload.analisis,
+                payload.recomendaciones,
+                payload.cosasPrevenir,
+                payload.infoAdicional,
+                completeness,
+                False,
+            )
+        except CardAIInputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        prompt = self._build_user_prompt(payload.tipo, titulo, payload)
+        llm_response = self._call_llm(prompt)
+
+        try:
+            content = llm_response["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise CardAIServiceError("La respuesta del modelo no contiene contenido utilizable.") from exc
+
+        try:
+            content_json = json.loads(content)
+        except ValueError as exc:
+            raise CardAIServiceError("El modelo no devolvió un JSON válido.") from exc
+
+        try:
+            output_dto = self._output_dao.create_output(
+                payload.cardId,
+                input_dto.inputId,
+                llm_response.get("id"),
+                llm_response.get("model"),
+                llm_response.get("usage"),
+                content_json,
+            )
+        except CardAIOutputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        return CardAIGenerationResultDTO(input=input_dto, output=output_dto, completenessPct=completeness)
+
+    def regenerate_from_input(self, input_id: int) -> CardAIGenerationResultDTO:
+        """Trigger a new generation using the stored input fields."""
+
+        try:
+            input_dto = self._input_dao.get_input(input_id)
+        except CardAIInputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        if not input_dto:
+            raise CardAIServiceError("La captura solicitada no existe.")
+
+        payload = CardAIRequestDTO(
+            cardId=input_dto.cardId,
+            tipo=input_dto.tipo,
+            descripcion=input_dto.descripcion,
+            analisis=input_dto.analisis,
+            recomendaciones=input_dto.recomendaciones,
+            cosasPrevenir=input_dto.cosasPrevenir,
+            infoAdicional=input_dto.infoAdicional,
+            forceSaveInputs=True,
+        )
+        return self.generate_document(payload)
+

--- a/app/views/cards_ai_view.py
+++ b/app/views/cards_ai_view.py
@@ -421,7 +421,11 @@ def _open_capture_form(
             try:
                 controller.save_draft(payload)
             except RuntimeError as exc:
-                win.after(0, lambda: messagebox.showerror("Error", str(exc)))
+                error_message = str(exc)
+                win.after(
+                    0,
+                    lambda message=error_message: messagebox.showerror("Error", message),
+                )
                 return
             win.after(0, lambda: messagebox.showinfo("Guardado", "Se guardó el borrador correctamente."))
 
@@ -451,7 +455,11 @@ def _open_capture_form(
             try:
                 result = controller.generate_document(payload)
             except RuntimeError as exc:
-                win.after(0, lambda: messagebox.showerror("Error", str(exc)))
+                error_message = str(exc)
+                win.after(
+                    0,
+                    lambda message=error_message: messagebox.showerror("Error", message),
+                )
                 return
             win.after(0, lambda: (win.destroy(), _show_generation_result(root, controller, card, result)))
 

--- a/app/views/cards_ai_view.py
+++ b/app/views/cards_ai_view.py
@@ -1,0 +1,630 @@
+"""Build the UI that orchestrates card selection and AI generations."""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime
+from typing import Callable, Dict, List, Optional
+import tkinter as tk
+from tkinter import filedialog, messagebox, ttk
+
+import ttkbootstrap as tb
+from ttkbootstrap.constants import *  # noqa: F401,F403
+from ttkbootstrap.widgets import DateEntry
+
+from app.controllers.card_ai_controller import CardAIController
+from app.dtos.card_ai_dto import CardAIGenerationResultDTO, CardAIHistoryEntryDTO, CardDTO
+
+
+TYPE_CHOICES = ("INCIDENCIA", "MEJORA", "HU")
+STATUS_CHOICES = ("pending", "in_progress", "done", "closed")
+
+
+def _format_datetime(value: Optional[datetime]) -> str:
+    """Return a friendly formatted datetime string."""
+
+    if not value:
+        return ""
+    return value.strftime("%Y-%m-%d %H:%M")
+
+
+def _calculate_completeness(fields: Dict[str, str]) -> int:
+    """Compute the completeness percentage mirroring the service logic."""
+
+    keys = ["descripcion", "analisis", "recomendaciones", "cosas_prevenir", "info_adicional"]
+    values = [fields.get(key, "").strip() for key in keys]
+    filled = sum(1 for value in values if value)
+    return round(100 * filled / len(values)) if values else 0
+
+
+def _progress_style(progress: tb.Progressbar, percentage: int) -> None:
+    """Adjust the progress bar style according to the completion percentage."""
+
+    if percentage < 34:
+        progress.configure(bootstyle="danger")
+    elif percentage < 67:
+        progress.configure(bootstyle="warning")
+    else:
+        progress.configure(bootstyle="success")
+
+
+def _export_json(content: Dict[str, object], parent: tk.Misc) -> None:
+    """Prompt for a JSON path and save the provided document."""
+
+    path = filedialog.asksaveasfilename(
+        parent=parent,
+        defaultextension=".json",
+        filetypes=[("JSON", "*.json")],
+        title="Exportar resultado a JSON",
+    )
+    if not path:
+        return
+    try:
+        with open(path, "w", encoding="utf-8") as handle:
+            json.dump(content, handle, ensure_ascii=False, indent=2)
+    except OSError as exc:
+        messagebox.showerror("Error", f"No se pudo exportar el JSON:\n{exc}")
+    else:
+        messagebox.showinfo("Exportado", f"Archivo guardado en:\n{path}")
+
+
+def _export_markdown(content: Dict[str, object], parent: tk.Misc) -> None:
+    """Transform the JSON into Markdown and persist it to disk."""
+
+    path = filedialog.asksaveasfilename(
+        parent=parent,
+        defaultextension=".md",
+        filetypes=[("Markdown", "*.md")],
+        title="Exportar resultado a Markdown",
+    )
+    if not path:
+        return
+    try:
+        lines: List[str] = ["# Documento generado"]
+        for key, value in content.items():
+            lines.append(f"\n## {key}")
+            if isinstance(value, list):
+                for item in value:
+                    lines.append(f"- {item}")
+            else:
+                lines.append(str(value))
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write("\n".join(lines))
+    except OSError as exc:
+        messagebox.showerror("Error", f"No se pudo exportar el Markdown:\n{exc}")
+    else:
+        messagebox.showinfo("Exportado", f"Archivo guardado en:\n{path}")
+
+
+def _export_docx(content: Dict[str, object], parent: tk.Misc) -> None:
+    """Generate a minimal DOCX using python-docx if available."""
+
+    try:
+        from docx import Document  # type: ignore
+    except ImportError:
+        messagebox.showerror(
+            "Dependencia faltante",
+            "No se encontró la librería 'python-docx'. Instala la dependencia para exportar a DOCX.",
+        )
+        return
+
+    path = filedialog.asksaveasfilename(
+        parent=parent,
+        defaultextension=".docx",
+        filetypes=[("Documento Word", "*.docx")],
+        title="Exportar resultado a DOCX",
+    )
+    if not path:
+        return
+
+    try:
+        document = Document()
+        document.add_heading("Documento DDE/HU", level=1)
+        for key, value in content.items():
+            document.add_heading(str(key), level=2)
+            if isinstance(value, list):
+                for item in value:
+                    document.add_paragraph(str(item), style="List Bullet")
+            else:
+                document.add_paragraph(str(value))
+        document.save(path)
+    except Exception as exc:  # pragma: no cover - depende de la librería externa
+        messagebox.showerror("Error", f"No se pudo exportar el DOCX:\n{exc}")
+    else:
+        messagebox.showinfo("Exportado", f"Archivo guardado en:\n{path}")
+
+
+def _show_history(parent: tk.Misc, controller: CardAIController, card_id: int) -> None:
+    """Display a modal window with the generation history for a card."""
+
+    try:
+        history = controller.list_history(card_id)
+    except RuntimeError as exc:
+        messagebox.showerror("Error", str(exc))
+        return
+
+    win = tb.Toplevel(parent)
+    win.title("Historial de generación")
+    win.geometry("820x520")
+    win.transient(parent)
+    win.grab_set()
+
+    frame = tb.Frame(win, padding=12)
+    frame.pack(fill=BOTH, expand=YES)
+
+    columns = ("fecha", "modelo", "completitud")
+    tree = ttk.Treeview(frame, columns=columns, show="headings", height=12)
+    tree.heading("fecha", text="Fecha")
+    tree.heading("modelo", text="Modelo")
+    tree.heading("completitud", text="Completitud")
+    tree.column("fecha", width=180)
+    tree.column("modelo", width=200)
+    tree.column("completitud", width=120, anchor="center")
+
+    scrollbar = ttk.Scrollbar(frame, orient="vertical", command=tree.yview)
+    tree.configure(yscrollcommand=scrollbar.set)
+    tree.pack(side=LEFT, fill=BOTH, expand=YES)
+    scrollbar.pack(side=RIGHT, fill=Y)
+
+    detail = tk.Text(win, height=10, wrap="word")
+    detail.pack(fill=BOTH, expand=YES, padx=12, pady=(0, 12))
+
+    entries_map: Dict[str, CardAIHistoryEntryDTO] = {}
+
+    def on_select(event: tk.Event | None) -> None:
+        """Render the JSON content for the selected history entry."""
+
+        selection = tree.selection()
+        if not selection:
+            return
+        item_id = selection[0]
+        entry = entries_map.get(item_id)
+        if not entry:
+            return
+        detail.configure(state="normal")
+        detail.delete("1.0", "end")
+        pretty = json.dumps(entry.output.content, ensure_ascii=False, indent=2)
+        detail.insert("1.0", pretty)
+        detail.configure(state="disabled")
+
+    for idx, entry in enumerate(history, start=1):
+        completeness = entry.input.completenessPct if entry.input else 0
+        item_id = f"row-{idx}"
+        tree.insert(
+            "",
+            "end",
+            iid=item_id,
+            values=(
+                _format_datetime(entry.output.createdAt),
+                entry.output.llmModel or "",
+                f"{completeness}%",
+            ),
+        )
+        entries_map[item_id] = entry
+
+    tree.bind("<<TreeviewSelect>>", on_select)
+    if history:
+        first = tree.get_children("")
+        if first:
+            tree.selection_set(first[0])
+            on_select(None)
+
+    win.wait_window()
+
+
+def _show_generation_result(
+    parent: tk.Misc,
+    controller: CardAIController,
+    card: CardDTO,
+    result: CardAIGenerationResultDTO,
+) -> None:
+    """Display the result window with export options."""
+
+    win = tb.Toplevel(parent)
+    win.title(f"Resultado para tarjeta {card.cardId}")
+    win.geometry("880x620")
+    win.transient(parent)
+    win.grab_set()
+
+    header = tb.Frame(win, padding=12)
+    header.pack(fill=X)
+    tb.Label(
+        header,
+        text=f"Tarjeta {card.cardId} - {card.title}",
+        font=("Segoe UI", 12, "bold"),
+    ).pack(anchor=W)
+    tb.Label(
+        header,
+        text=f"Completitud: {result.completenessPct}% - Modelo: {result.output.llmModel or 'N/D'}",
+        bootstyle=SECONDARY,
+    ).pack(anchor=W, pady=(4, 0))
+
+    text = tk.Text(win, wrap="word")
+    text.pack(fill=BOTH, expand=YES, padx=12, pady=8)
+    text.configure(state="normal")
+    pretty = json.dumps(result.output.content, ensure_ascii=False, indent=2)
+    text.insert("1.0", pretty)
+    text.configure(state="disabled")
+
+    actions = tb.Frame(win, padding=12)
+    actions.pack(fill=X)
+
+    tb.Button(
+        actions,
+        text="Exportar JSON",
+        bootstyle=SECONDARY,
+        command=lambda: _export_json(result.output.content, win),
+    ).pack(side=LEFT)
+    tb.Button(
+        actions,
+        text="Exportar Markdown",
+        bootstyle=SECONDARY,
+        command=lambda: _export_markdown(result.output.content, win),
+    ).pack(side=LEFT, padx=6)
+    tb.Button(
+        actions,
+        text="Exportar DOCX",
+        bootstyle=SECONDARY,
+        command=lambda: _export_docx(result.output.content, win),
+    ).pack(side=LEFT, padx=6)
+
+    tb.Button(
+        actions,
+        text="Historial",
+        bootstyle=INFO,
+        command=lambda: _show_history(parent, controller, card.cardId),
+    ).pack(side=RIGHT)
+
+    def regenerate() -> None:
+        """Trigger a new generation using the stored input."""
+
+        if not messagebox.askyesno("Regenerar", "¿Deseas generar nuevamente con los mismos datos?"):
+            return
+        try:
+            new_result = controller.regenerate(result.input.inputId)
+        except RuntimeError as exc:
+            messagebox.showerror("Error", str(exc))
+            return
+        win.destroy()
+        _show_generation_result(parent, controller, card, new_result)
+
+    tb.Button(actions, text="Regenerar", bootstyle=PRIMARY, command=regenerate).pack(side=RIGHT, padx=(0, 8))
+
+    win.wait_window()
+
+
+def _open_capture_form(
+    root: tk.Misc,
+    controller: CardAIController,
+    card: CardDTO,
+) -> None:
+    """Render the modal form that captures the generation inputs."""
+
+    win = tb.Toplevel(root)
+    win.title(f"Captura para tarjeta {card.cardId}")
+    win.geometry("840x620")
+    win.transient(root)
+    win.grab_set()
+
+    vars_data = {
+        "tipo": tk.StringVar(value=card.cardType or TYPE_CHOICES[0]),
+        "descripcion": tk.StringVar(value=""),
+        "analisis": tk.StringVar(value=""),
+        "recomendaciones": tk.StringVar(value=""),
+        "cosas_prevenir": tk.StringVar(value=""),
+        "info_adicional": tk.StringVar(value=""),
+    }
+
+    def _as_payload() -> Dict[str, object]:
+        """Collect the current state of the form."""
+
+        return {
+            "cardId": card.cardId,
+            "tipo": vars_data["tipo"].get(),
+            "descripcion": descripcion.get("1.0", "end").strip(),
+            "analisis": analisis.get("1.0", "end").strip(),
+            "recomendaciones": recomendaciones.get("1.0", "end").strip(),
+            "cosasPrevenir": prevenir.get("1.0", "end").strip(),
+            "infoAdicional": adicional.get("1.0", "end").strip(),
+        }
+
+    def _update_progress(*_args: object) -> None:
+        """Recalculate completeness when fields change."""
+
+        payload = _as_payload()
+        completeness = _calculate_completeness(
+            {
+                "descripcion": payload["descripcion"],
+                "analisis": payload["analisis"],
+                "recomendaciones": payload["recomendaciones"],
+                "cosas_prevenir": payload["cosasPrevenir"],
+                "info_adicional": payload["infoAdicional"],
+            }
+        )
+        progress.configure(value=completeness)
+        _progress_style(progress, completeness)
+        status.set(f"Completitud estimada: {completeness}%")
+
+    container = tb.Frame(win, padding=12)
+    container.pack(fill=BOTH, expand=YES)
+
+    tb.Label(
+        container,
+        text=f"Tarjeta {card.cardId}: {card.title}",
+        font=("Segoe UI", 12, "bold"),
+    ).grid(row=0, column=0, columnspan=2, sticky="w", pady=(0, 8))
+
+    tb.Label(container, text="Tipo").grid(row=1, column=0, sticky="w")
+    tipo_box = ttk.Combobox(container, values=list(TYPE_CHOICES), textvariable=vars_data["tipo"], state="readonly")
+    tipo_box.grid(row=1, column=1, sticky="we")
+
+    descripcion = tk.Text(container, height=5, wrap="word")
+    analisis = tk.Text(container, height=5, wrap="word")
+    recomendaciones = tk.Text(container, height=5, wrap="word")
+    prevenir = tk.Text(container, height=5, wrap="word")
+    adicional = tk.Text(container, height=4, wrap="word")
+
+    labels = [
+        ("Descripción", descripcion),
+        ("Análisis", analisis),
+        ("Recomendaciones", recomendaciones),
+        ("Cosas a prevenir", prevenir),
+        ("Información adicional", adicional),
+    ]
+    row = 2
+    for label, widget in labels:
+        tb.Label(container, text=label).grid(row=row, column=0, sticky="nw", pady=(8, 0))
+        widget.grid(row=row, column=1, sticky="nsew", pady=(8, 0))
+        row += 1
+
+    container.grid_columnconfigure(1, weight=1)
+    for idx in range(2, row):
+        container.grid_rowconfigure(idx, weight=1)
+
+    status = tk.StringVar(value="Completa los campos para mejorar el resultado.")
+    progress = tb.Progressbar(container, maximum=100, bootstyle="danger")
+    progress.grid(row=row, column=0, columnspan=2, sticky="we", pady=(12, 0))
+    tb.Label(container, textvariable=status, bootstyle=SECONDARY).grid(row=row + 1, column=0, columnspan=2, sticky="w")
+
+    buttons = tb.Frame(container)
+    buttons.grid(row=row + 2, column=0, columnspan=2, sticky="we", pady=(12, 0))
+
+    running = tk.BooleanVar(value=False)
+
+    def _set_running(value: bool) -> None:
+        """Enable or disable the action buttons."""
+
+        running.set(value)
+        state = tk.DISABLED if value else tk.NORMAL
+        for button in buttons.winfo_children():
+            button.configure(state=state)
+
+    def _background_call(func: Callable[[], None]) -> None:
+        """Execute the given callable in a worker thread."""
+
+        def worker() -> None:
+            try:
+                func()
+            finally:
+                win.after(0, lambda: _set_running(False))
+
+        _set_running(True)
+        threading.Thread(target=worker, daemon=True).start()
+
+    def _save_draft() -> None:
+        """Save the current content as draft."""
+
+        payload = _as_payload()
+
+        def _task() -> None:
+            try:
+                controller.save_draft(payload)
+            except RuntimeError as exc:
+                win.after(0, lambda: messagebox.showerror("Error", str(exc)))
+                return
+            win.after(0, lambda: messagebox.showinfo("Guardado", "Se guardó el borrador correctamente."))
+
+        _background_call(_task)
+
+    def _generate() -> None:
+        """Call the controller to generate the document."""
+
+        payload = _as_payload()
+        completeness = _calculate_completeness(
+            {
+                "descripcion": payload["descripcion"],
+                "analisis": payload["analisis"],
+                "recomendaciones": payload["recomendaciones"],
+                "cosas_prevenir": payload["cosasPrevenir"],
+                "info_adicional": payload["infoAdicional"],
+            }
+        )
+        if completeness < 34:
+            if not messagebox.askyesno(
+                "Completitud baja",
+                "La completitud es menor al 34%. ¿Deseas continuar de todos modos?",
+            ):
+                return
+
+        def _task() -> None:
+            try:
+                result = controller.generate_document(payload)
+            except RuntimeError as exc:
+                win.after(0, lambda: messagebox.showerror("Error", str(exc)))
+                return
+            win.after(0, lambda: (win.destroy(), _show_generation_result(root, controller, card, result)))
+
+        _background_call(_task)
+
+    tb.Button(buttons, text="Guardar borrador", bootstyle=SECONDARY, command=_save_draft).pack(side=LEFT)
+    tb.Button(buttons, text="Generar (IA)", bootstyle=PRIMARY, command=_generate).pack(side=LEFT, padx=6)
+    tb.Button(buttons, text="Cancelar", bootstyle=DANGER, command=win.destroy).pack(side=RIGHT)
+
+    for widget in (descripcion, analisis, recomendaciones, prevenir, adicional):
+        widget.bind("<KeyRelease>", _update_progress, add="+")
+
+    _update_progress()
+    win.wait_window()
+
+
+def build_cards_ai_view(
+    root: tk.Misc,
+    parent: tb.Frame,
+    controller: CardAIController,
+    bind_mousewheel: Callable[[tk.Widget, Callable[..., None]], None],
+) -> None:
+    """Populate the cards AI assistant view inside the provided frame."""
+
+    for widget in parent.winfo_children():
+        widget.destroy()
+
+    filters_frame = tb.Frame(parent, padding=12)
+    filters_frame.pack(fill=X)
+
+    tb.Label(filters_frame, text="Tipo").grid(row=0, column=0, sticky="w")
+    tipo_var = tk.StringVar(value="")
+    tipo_box = ttk.Combobox(filters_frame, values=("",) + TYPE_CHOICES, textvariable=tipo_var, width=16)
+    tipo_box.grid(row=1, column=0, sticky="we", padx=(0, 10))
+
+    tb.Label(filters_frame, text="Status").grid(row=0, column=1, sticky="w")
+    status_var = tk.StringVar(value="")
+    status_box = ttk.Combobox(filters_frame, values=("",) + STATUS_CHOICES, textvariable=status_var, width=16)
+    status_box.grid(row=1, column=1, sticky="we", padx=(0, 10))
+
+    tb.Label(filters_frame, text="Fecha inicio").grid(row=0, column=2, sticky="w")
+    start_var = DateEntry(filters_frame, dateformat="%Y-%m-%d")
+    start_var.grid(row=1, column=2, sticky="we", padx=(0, 10))
+    start_var.entry.delete(0, tk.END)
+
+    tb.Label(filters_frame, text="Fecha fin").grid(row=0, column=3, sticky="w")
+    end_var = DateEntry(filters_frame, dateformat="%Y-%m-%d")
+    end_var.grid(row=1, column=3, sticky="we", padx=(0, 10))
+    end_var.entry.delete(0, tk.END)
+
+    tb.Label(filters_frame, text="Buscar").grid(row=0, column=4, sticky="w")
+    search_var = tk.StringVar(value="")
+    search_entry = tb.Entry(filters_frame, textvariable=search_var)
+    search_entry.grid(row=1, column=4, sticky="we")
+
+    filters_frame.grid_columnconfigure(4, weight=1)
+
+    table_frame = tb.Frame(parent, padding=(12, 0))
+    table_frame.pack(fill=BOTH, expand=YES)
+
+    columns = ("id", "titulo", "tipo", "status", "actualizado")
+    tree = ttk.Treeview(table_frame, columns=columns, show="headings", height=14)
+    tree.heading("id", text="ID")
+    tree.heading("titulo", text="Título")
+    tree.heading("tipo", text="Tipo")
+    tree.heading("status", text="Status")
+    tree.heading("actualizado", text="Actualizado")
+    tree.column("id", width=80, anchor="center")
+    tree.column("titulo", width=360)
+    tree.column("tipo", width=120)
+    tree.column("status", width=120)
+    tree.column("actualizado", width=160)
+
+    scrollbar = ttk.Scrollbar(table_frame, orient="vertical", command=tree.yview)
+    tree.configure(yscrollcommand=scrollbar.set)
+    tree.pack(side=LEFT, fill=BOTH, expand=YES)
+    scrollbar.pack(side=RIGHT, fill=Y)
+    bind_mousewheel(tree, tree.yview)
+
+    actions_frame = tb.Frame(parent, padding=12)
+    actions_frame.pack(fill=X)
+    status_label = tb.Label(actions_frame, text="Selecciona una tarjeta para comenzar.", bootstyle=SECONDARY)
+    status_label.pack(side=LEFT)
+    generate_button = tb.Button(
+        actions_frame,
+        text="Generar DDE/HU",
+        bootstyle=PRIMARY,
+        state=tk.DISABLED,
+        command=lambda: _open_capture_form(root, controller, selected_card[0]) if selected_card else None,
+    )
+    generate_button.pack(side=RIGHT)
+
+    selected_card: List[CardDTO] = []
+    current_cards: List[CardDTO] = []
+
+    def _parse_date(entry: DateEntry) -> Optional[datetime]:
+        """Return the selected date or ``None`` when the field is empty."""
+
+        value = entry.entry.get().strip()
+        if not value:
+            return None
+        try:
+            return datetime.strptime(value + " 00:00", "%Y-%m-%d %H:%M")
+        except ValueError:
+            return None
+
+    def _refresh() -> None:
+        """Load the cards from the controller applying filters."""
+
+        filters = {
+            "tipo": tipo_var.get().strip() or None,
+            "status": status_var.get().strip() or None,
+            "fechaInicio": _parse_date(start_var),
+            "fechaFin": _parse_date(end_var),
+            "busqueda": search_var.get().strip() or None,
+        }
+        try:
+            cards = controller.list_cards(filters)
+        except RuntimeError as exc:
+            messagebox.showerror("Error", str(exc))
+            return
+
+        current_cards[:] = cards
+        selected_card.clear()
+        generate_button.configure(state=tk.DISABLED)
+        tree.delete(*tree.get_children(""))
+        for card in cards:
+            tree.insert(
+                "",
+                "end",
+                iid=str(card.cardId),
+                values=(
+                    card.cardId,
+                    card.title,
+                    card.cardType,
+                    card.status,
+                    _format_datetime(card.updatedAt or card.createdAt),
+                ),
+            )
+        status_label.configure(text=f"{len(cards)} tarjeta(s) encontradas.")
+
+    def _on_select(event: tk.Event) -> None:
+        """Enable the generate button when a card is selected."""
+
+        selection = tree.selection()
+        if not selection:
+            selected_card.clear()
+            generate_button.configure(state=tk.DISABLED)
+            return
+        card_id = int(selection[0])
+        for card in current_cards:
+            if card.cardId == card_id:
+                selected_card[:] = [card]
+                break
+        generate_button.configure(state=tk.NORMAL if selected_card else tk.DISABLED)
+
+    tree.bind("<<TreeviewSelect>>", _on_select)
+
+    debounce_id = None
+
+    def _schedule_refresh(*_args: object) -> None:
+        """Apply debounce to the search entry."""
+
+        nonlocal debounce_id
+        if debounce_id is not None:
+            parent.after_cancel(debounce_id)
+        debounce_id = parent.after(300, _refresh)
+
+    for widget in (tipo_box, status_box):
+        widget.bind("<<ComboboxSelected>>", lambda *_: _refresh(), add="+")
+    start_var.bind("<<DateEntrySelected>>", lambda *_: _refresh(), add="+")
+    end_var.bind("<<DateEntrySelected>>", lambda *_: _refresh(), add="+")
+    search_var.trace_add("write", lambda *_: _schedule_refresh())
+
+    _refresh()
+

--- a/app/views/cards_ai_view.py
+++ b/app/views/cards_ai_view.py
@@ -395,10 +395,16 @@ def _open_capture_form(
     def _set_running(value: bool) -> None:
         """Enable or disable the action buttons."""
 
+        if not buttons.winfo_exists():
+            return
+
         running.set(value)
         state = tk.DISABLED if value else tk.NORMAL
         for button in buttons.winfo_children():
-            button.configure(state=state)
+            try:
+                button.configure(state=state)
+            except tk.TclError:
+                continue
 
     def _background_call(func: Callable[[], None]) -> None:
         """Execute the given callable in a worker thread."""
@@ -407,7 +413,10 @@ def _open_capture_form(
             try:
                 func()
             finally:
-                win.after(0, lambda: _set_running(False))
+                try:
+                    win.after(0, lambda: _set_running(False))
+                except tk.TclError:
+                    _set_running(False)
 
         _set_running(True)
         threading.Thread(target=worker, daemon=True).start()

--- a/app/views/main_view.py
+++ b/app/views/main_view.py
@@ -84,6 +84,7 @@ from app.views.alta_ciclos_view import build_alta_ciclos_view
 from app.views.modificacion_ciclos_view import build_modificacion_ciclos_view
 from app.views.pruebas_view import PruebasViewContext, build_pruebas_view
 from app.views.login_view import build_login_view
+from app.views.cards_ai_view import build_cards_ai_view
 
 # --- helper: enable mouse wheel scrolling on canvas/treeview ---
 def _bind_mousewheel(_widget, _yview_callable):
@@ -282,6 +283,7 @@ def run_gui():
     frame_gen_auto   = tb.Frame(content_area, padding=(16,10))
     frame_gen_manual = tb.Frame(content_area, padding=(16,10))
     frame_mod_matriz = tb.Frame(content_area, padding=(16,10))
+    frame_cards_ai   = tb.Frame(content_area, padding=(16,10))
     frame_alta_cic   = tb.Frame(content_area, padding=(16,10))
     frame_mod_cic    = tb.Frame(content_area, padding=(16,10))
     frame_pruebas    = tb.Frame(content_area, padding=(16,0))   # flujo existente
@@ -336,6 +338,7 @@ def run_gui():
 
     build_generacion_manual_view(app, frame_gen_manual, _bind_mousewheel)
     build_modificacion_matriz_view(frame_mod_matriz)
+    build_cards_ai_view(app, frame_cards_ai, controller.cardsAI, _bind_mousewheel)
     build_alta_ciclos_view(frame_alta_cic)
     build_modificacion_ciclos_view(frame_mod_cic)
 
@@ -351,6 +354,7 @@ def run_gui():
     _cards_grid(frame_launcher, [
         ("Generación Automática", "Matrices por lote",               "⚙️", lambda: go_section("GEN_AUTO", from_launcher=True)),
         ("Generación Manual",     "Genera una matriz puntual",       "✍️", lambda: go_section("GEN_MANUAL", from_launcher=True)),
+        ("Generador DDE/HU",      "Documentos asistidos por IA",     "🤖", lambda: go_section("CARDS_AI", from_launcher=True)),
         ("Modificación de Matriz","Busca y edita matrices",          "📝", lambda: go_section("MOD_MATRIZ", from_launcher=True)),
         ("Alta de Ciclos",        "Crea ciclos nuevos",              "➕", lambda: go_section("ALTA_CICLOS", from_launcher=True)),
         ("Modificación de Ciclos","Actualiza ciclos existentes",     "✏️", lambda: go_section("MOD_CICLOS", from_launcher=True)),
@@ -377,6 +381,7 @@ def run_gui():
     _nav_item(sidebar, "✍️", "Generación Manual",     "GEN_MANUAL")
     tb.Separator(sidebar, bootstyle=SECONDARY).pack(fill=X, pady=8)
     _nav_item(sidebar, "📝", "Modificación de Matriz", "MOD_MATRIZ")
+    _nav_item(sidebar, "🤖", "Generador DDE/HU", "CARDS_AI")
     _nav_item(sidebar, "➕", "Alta de Ciclos",          "ALTA_CICLOS")
     _nav_item(sidebar, "✏️", "Modificación de Ciclos", "MOD_CICLOS")
     tb.Separator(sidebar, bootstyle=SECONDARY).pack(fill=X, pady=8)
@@ -388,6 +393,7 @@ def run_gui():
         "GEN_AUTO": frame_gen_auto,
         "GEN_MANUAL": frame_gen_manual,
         "MOD_MATRIZ": frame_mod_matriz,
+        "CARDS_AI": frame_cards_ai,
         "ALTA_CICLOS": frame_alta_cic,
         "MOD_CICLOS": frame_mod_cic,
         "PRUEBAS": frame_pruebas,

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -416,4 +416,37 @@ CREATE TABLE dbo.config_deploy_user_paths (
     CONSTRAINT uq_config_deploy_user_paths UNIQUE (group_key, target_name, username),
     CONSTRAINT fk_config_deploy_user_paths_group FOREIGN KEY (group_key) REFERENCES dbo.config_groups([key]) ON DELETE CASCADE
 );
+
+CREATE TABLE dbo.cards_ai_inputs (
+    input_id BIGINT IDENTITY(1,1) PRIMARY KEY,
+    card_id BIGINT NOT NULL,
+    tipo VARCHAR(20) NOT NULL,
+    descripcion NVARCHAR(MAX) NULL,
+    analisis NVARCHAR(MAX) NULL,
+    recomendaciones NVARCHAR(MAX) NULL,
+    cosas_prevenir NVARCHAR(MAX) NULL,
+    info_adicional NVARCHAR(MAX) NULL,
+    completeness_pct TINYINT NOT NULL DEFAULT(0),
+    is_draft BIT NOT NULL DEFAULT(1),
+    created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT fk_cards_ai_inputs_card FOREIGN KEY (card_id) REFERENCES dbo.cards(id) ON DELETE CASCADE
+);
+
+CREATE INDEX ix_cards_ai_inputs_card_id ON dbo.cards_ai_inputs (card_id DESC, input_id DESC);
+
+CREATE TABLE dbo.cards_ai_outputs (
+    output_id BIGINT IDENTITY(1,1) PRIMARY KEY,
+    card_id BIGINT NOT NULL,
+    input_id BIGINT NULL,
+    llm_id VARCHAR(100) NULL,
+    llm_model VARCHAR(100) NULL,
+    llm_usage_json NVARCHAR(MAX) NULL,
+    content_json NVARCHAR(MAX) NOT NULL,
+    created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT fk_cards_ai_outputs_card FOREIGN KEY (card_id) REFERENCES dbo.cards(id) ON DELETE CASCADE,
+    CONSTRAINT fk_cards_ai_outputs_input FOREIGN KEY (input_id) REFERENCES dbo.cards_ai_inputs(input_id) ON DELETE SET NULL
+);
+
+CREATE INDEX ix_cards_ai_outputs_card_id ON dbo.cards_ai_outputs (card_id DESC, output_id DESC);
 ```

--- a/tests/test_card_ai_service.py
+++ b/tests/test_card_ai_service.py
@@ -1,0 +1,233 @@
+import json
+from datetime import datetime, timezone
+from typing import Dict, List
+
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.dtos.card_ai_dto import CardAIRequestDTO, CardDTO, CardFiltersDTO
+from app.services.card_ai_service import CardAIService, CardAIServiceError
+
+
+class FakeCardDAO:
+    """Minimal DAO providing cards for the tests."""
+
+    def __init__(self) -> None:
+        self.cards: Dict[int, CardDTO] = {
+            1: CardDTO(
+                cardId=1,
+                title="EA-172 No genera vencimientos",
+                cardType="INCIDENCIA",
+                status="pending",
+                createdAt=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                updatedAt=datetime(2024, 1, 2, tzinfo=timezone.utc),
+                ticketId="EA-172",
+                branchKey="feature/ea-172",
+            )
+        }
+
+    def list_cards(self, filters: CardFiltersDTO, limit: int = 200) -> List[CardDTO]:  # pragma: no cover - utilizado indirectamente
+        return list(self.cards.values())[:limit]
+
+    def get_card_title(self, card_id: int) -> str:
+        if card_id not in self.cards:
+            raise RuntimeError("not found")
+        return self.cards[card_id].title
+
+
+class FakeInputDAO:
+    """Persist inputs in memory for the service tests."""
+
+    def __init__(self) -> None:
+        self.created: List[Dict[str, object]] = []
+        self._next_id = 1
+
+    def create_input(
+        self,
+        card_id: int,
+        tipo: str,
+        descripcion: str,
+        analisis: str,
+        recomendaciones: str,
+        cosas_prevenir: str,
+        info_adicional: str,
+        completeness_pct: int,
+        is_draft: bool,
+    ):
+        input_id = self._next_id
+        self._next_id += 1
+        dto = type("InputDTO", (), {})()
+        dto.inputId = input_id
+        dto.cardId = card_id
+        dto.tipo = tipo
+        dto.descripcion = descripcion
+        dto.analisis = analisis
+        dto.recomendaciones = recomendaciones
+        dto.cosasPrevenir = cosas_prevenir
+        dto.infoAdicional = info_adicional
+        dto.completenessPct = completeness_pct
+        dto.isDraft = is_draft
+        dto.createdAt = datetime.now(timezone.utc)
+        dto.updatedAt = dto.createdAt
+        self.created.append({"dto": dto, "is_draft": is_draft})
+        return dto
+
+    def list_by_card(self, card_id: int, limit: int = 50):  # pragma: no cover - no se usa en estas pruebas
+        return []
+
+    def get_input(self, input_id: int):
+        for entry in self.created:
+            dto = entry["dto"]
+            if dto.inputId == input_id:
+                return dto
+        return None
+
+
+class FakeOutputDAO:
+    """Store LLM outputs without persisting them to SQL Server."""
+
+    def __init__(self) -> None:
+        self.created: List[Dict[str, object]] = []
+        self._next_id = 1
+
+    def create_output(
+        self,
+        card_id: int,
+        input_id: int,
+        llm_id: str,
+        llm_model: str,
+        llm_usage: dict,
+        content: dict,
+    ):
+        output_id = self._next_id
+        self._next_id += 1
+        dto = type("OutputDTO", (), {})()
+        dto.outputId = output_id
+        dto.cardId = card_id
+        dto.inputId = input_id
+        dto.llmId = llm_id
+        dto.llmModel = llm_model
+        dto.llmUsage = llm_usage
+        dto.content = content
+        dto.createdAt = datetime.now(timezone.utc)
+        self.created.append(dto)
+        return dto
+
+    def list_by_card(self, card_id: int, limit: int = 50):  # pragma: no cover - no se usa en estas pruebas
+        return []
+
+
+class FakeResponse:
+    """Minimal requests.Response stand-in used for the LLM client."""
+
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+        self.ok = status_code == 200
+        self.text = json.dumps(payload)
+
+    def json(self) -> dict:
+        return self._payload
+
+
+def successful_http_post(*_args, **_kwargs) -> FakeResponse:
+    """Return a fake response mimicking a successful completion."""
+
+    return FakeResponse(
+        {
+            "id": "chatcmpl-1",
+            "model": "qwen/qwen2.5-vl-7b",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": json.dumps({"titulo": "Demo", "requerimientos_funcionales": []}),
+                    }
+                }
+            ],
+            "usage": {"total_tokens": 10},
+        }
+    )
+
+
+def failing_http_post(*_args, **_kwargs) -> FakeResponse:
+    """Return a fake response indicating a server failure."""
+
+    return FakeResponse({}, status_code=500)
+
+
+def test_calculate_completeness_counts_non_empty_fields() -> None:
+    """The completeness helper should consider the number of filled fields."""
+
+    service = CardAIService(FakeCardDAO(), FakeInputDAO(), FakeOutputDAO(), http_post=successful_http_post)
+    payload = CardAIRequestDTO(
+        cardId=1,
+        tipo="INCIDENCIA",
+        descripcion="Uno",
+        analisis="Dos",
+        recomendaciones="",
+        cosasPrevenir=None,
+        infoAdicional="Tres",
+    )
+    assert CardAIService.calculate_completeness(payload) == 60
+
+
+def test_save_draft_persists_input_and_marks_as_draft() -> None:
+    """Drafts should be flagged without contacting the LLM."""
+
+    fake_input = FakeInputDAO()
+    service = CardAIService(FakeCardDAO(), fake_input, FakeOutputDAO(), http_post=successful_http_post)
+    payload = CardAIRequestDTO(
+        cardId=1,
+        tipo="INCIDENCIA",
+        descripcion="Descripción",
+        analisis="",
+        recomendaciones="",
+        cosasPrevenir="",
+        infoAdicional="",
+    )
+    dto = service.save_draft(payload)
+    assert dto.isDraft is True
+    assert fake_input.created[0]["is_draft"] is True
+
+
+def test_generate_document_calls_llm_and_stores_output() -> None:
+    """A successful generation should persist input and output DTOs."""
+
+    fake_input = FakeInputDAO()
+    fake_output = FakeOutputDAO()
+    service = CardAIService(FakeCardDAO(), fake_input, fake_output, http_post=successful_http_post)
+    payload = CardAIRequestDTO(
+        cardId=1,
+        tipo="INCIDENCIA",
+        descripcion="Descripción",
+        analisis="",
+        recomendaciones="",
+        cosasPrevenir="",
+        infoAdicional="",
+    )
+    result = service.generate_document(payload)
+    assert result.input.inputId == fake_input.created[0]["dto"].inputId
+    assert result.output.outputId == fake_output.created[0].outputId
+    assert result.output.content["titulo"] == "Demo"
+
+
+def test_generate_document_handles_llm_errors() -> None:
+    """Non-200 responses from the LLM should raise a service error."""
+
+    service = CardAIService(FakeCardDAO(), FakeInputDAO(), FakeOutputDAO(), http_post=failing_http_post)
+    payload = CardAIRequestDTO(
+        cardId=1,
+        tipo="INCIDENCIA",
+        descripcion="Descripción",
+        analisis="",
+        recomendaciones="",
+        cosasPrevenir="",
+        infoAdicional="",
+    )
+    with pytest.raises(CardAIServiceError):
+        service.generate_document(payload)


### PR DESCRIPTION
## Summary
- add configuration, data access, service and controller layers to generate DDE/HU documents via the local LLM
- implement a dedicated Tkinter view with filters, live search, capture form, exports and history for card-based documents
- document the new SQL Server tables and cover the service with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690172cbe3e4832c9714e86096f98c0f