### PR TITLE
Adjust HTML export template markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.8.2] - 2024-06-04
+### Added
+- Exportación de resultados en HTML utilizando la plantilla editable `app/templates/card_generation.html`.
+- Prueba unitaria que verifica la inyección de valores de texto y listas en la nueva exportación HTML.
+ 
+### Changed
+- La plantilla `card_generation.html` ahora coincide con el formato solicitado manteniendo todo el estilo embebido en las mismas etiquetas de la tabla.
+
 ## [0.8.1] - 2024-06-03
 ### Changed
 - La solicitud al asistente de IA ahora antepone un mensaje de sistema con las directrices corporativas y actualiza el prompt del usuario para reflejar el nuevo esquema JSON requerido.

--- a/app/templates/__init__.py
+++ b/app/templates/__init__.py
@@ -1,0 +1,1 @@
+"""HTML templates used for exporting AI generation results."""

--- a/app/templates/card_generation.html
+++ b/app/templates/card_generation.html
@@ -1,0 +1,155 @@
+<table>
+  <!-- Encabezado superior -->
+  <tbody>
+    <tr>
+      <td style="background-color: #998DD9;">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Fecha</strong></p>
+        </div>
+      </td>
+      <td style="background-color: #998DD9;">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Hora Inicio</strong></p>
+        </div>
+      </td>
+      <td style="background-color: #998DD9;">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Hora Fin</strong></p>
+        </div>
+      </td>
+      <td style="background-color: #998DD9;">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Lugar</strong></p>
+        </div>
+      </td>
+    </tr>
+    <tr style="background:#0b0b12;">
+      <td style="padding:12px; border:1px solid #C0B6F2;">{{fecha}}</td>
+      <td style="padding:12px; border:1px solid #C0B6F2;">{{hora_inicio}}</td>
+      <td style="padding:12px; border:1px solid #C0B6F2;">{{hora_fin}}</td>
+      <td style="padding:12px; border:1px solid #C0B6F2;">{{lugar}}</td>
+    </tr>
+    <tr style="background:#0b0b12;">
+      <td colspan="4" style="padding:20px 12px; border:1px solid #C0B6F2; text-align:center; font-size:18px;">
+        {{titulo}}
+      </td>
+    </tr>
+    <tr style="background:#0b0b12;">
+      <td colspan="4" style="padding:16px 12px; border:1px solid #C0B6F2; text-align:center;">
+        {{tipo}}
+      </td>
+    </tr>
+
+    <!-- Requerimiento de Usuario -->
+    <tr style="background:#bf2cbd;">
+      <th style="background-color: #998DD9;" colspan="4">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Requerimiento de Usuario</strong></p>
+        </div>
+      </th>
+    </tr>
+
+    <!-- ¿Qué necesitas? -->
+    <tr>
+      <th style="background-color: #C0B6F2;" colspan="4">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>¿Qué necesitas</strong></p>
+        </div>
+      </th>
+    </tr>
+    <tr style="background:#0b0b12;">
+      <td colspan="4" style="padding:28px 12px; border:1px solid #C0B6F2;">{{que_necesitas}}</td>
+    </tr>
+
+    <!-- ¿Para qué lo necesitas? -->
+    <tr>
+      <th style="background-color: #C0B6F2;" colspan="4">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>¿Para qué lo necesitas?</strong></p>
+        </div>
+      </th>
+    </tr>
+    <tr style="background:#0b0b12;">
+      <td colspan="4" style="padding:28px 12px; border:1px solid #C0B6F2;">{{para_que_lo_necesitas}}</td>
+    </tr>
+
+    <!-- ¿Cómo lo necesitas? -->
+    <tr>
+      <th style="background-color: #C0B6F2;" colspan="4">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>¿Cómo lo necesitas?</strong></p>
+        </div>
+      </th>
+    </tr>
+    <tr style="background:#0b0b12;">
+      <td colspan="4" style="padding:40px 12px; border:1px solid #C0B6F2;">{{como_lo_necesitas}}</td>
+    </tr>
+
+    <!-- Requerimientos funcionales -->
+    <tr style="background:#7B2CBF;">
+      <th style="background-color: #998DD9;" colspan="4">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Requerimientos funcionales</strong></p>
+        </div>
+      </th>
+    </tr>
+    <tr style="background:#0b0b12;">
+      <td colspan="4" style="padding:50px 12px; border:1px solid #C0B6F2;">{{requerimientos_funcionales}}</td>
+    </tr>
+
+    <!-- Requerimientos Especiales -->
+    <tr style="background:#7B2CBF;">
+      <th style="background-color: #998DD9;" colspan="4">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Requerimientos Especiales</strong></p>
+        </div>
+      </th>
+    </tr>
+    <tr style="background:#0b0b12;">
+      <td colspan="4" style="padding:50px 12px; border:1px solid #C0B6F2;">{{requerimientos_especiales}}</td>
+    </tr>
+
+    <!-- Criterios de aceptación -->
+    <tr style="background:#7B2CBF;">
+      <th style="background-color: #998DD9;" colspan="4">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Criterios de aceptación</strong></p>
+        </div>
+      </th>
+    </tr>
+    <tr style="background:#0b0b12;">
+      <td colspan="4" style="padding:50px 12px; border:1px solid #C0B6F2;">{{criterios_aceptacion}}</td>
+    </tr>
+
+    <!-- Participantes -->
+    <tr style="background:#7B2CBF;">
+      <th style="background-color: #998DD9;" colspan="4">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Participantes</strong></p>
+        </div>
+      </th>
+    </tr>
+    <tr style="background:#2a1a3d;">
+      <th style="background-color: #998DD9;" colspan="2">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Nombre comple</strong></p>
+        </div>
+      </th>
+      <th style="background-color: #998DD9;">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Área o Empresa</strong></p>
+        </div>
+      </th>
+      <th style="background-color: #998DD9;">
+        <div class="fabric-editor-block-mark fabric-editor-alignment fabric-editor-align-center" data-align="center">
+          <p><strong>Firmas</strong></p>
+        </div>
+      </th>
+    </tr>
+    <tr style="background:#0b0b12;">
+      <td colspan="2" style="padding:16px; border:1px solid #C0B6F2;">&nbsp;</td>
+      <td style="padding:16px; border:1px solid #C0B6F2;">&nbsp;</td>
+      <td style="padding:16px; border:1px solid #C0B6F2;">&nbsp;</td>
+    </tr>
+  </tbody>
+</table>

--- a/tests/test_cards_ai_view_html.py
+++ b/tests/test_cards_ai_view_html.py
@@ -1,0 +1,40 @@
+"""Validate the HTML export helpers used by the cards AI view."""
+
+import pytest
+
+
+_ = pytest.importorskip("ttkbootstrap")
+
+from app.views.cards_ai_view import _build_html_document
+
+
+def test_build_html_document_injects_text_and_lists() -> None:
+    """The HTML export should render strings, lists and fallbacks correctly."""
+
+    content = {
+        "titulo": "REQ-001 - Ajuste de timbrado",
+        "tipo": "MEJORA",
+        "fecha": "2024-06-03",
+        "hora_inicio": "09:00",
+        "hora_fin": "10:30",
+        "lugar": "Sistemas Premium",
+        "que_necesitas": "Actualizar el motor de timbrado.\nCon compatibilidad con PAC.",
+        "para_que_lo_necesitas": "Garantizar el timbrado oportuno de CFDI.",
+        "como_lo_necesitas": "Implementar validaciones adicionales en el proceso.",
+        "requerimientos_funcionales": [
+            "El sistema debe recalcular impuestos antes de timbrar.",
+            "Registrar bitácora de timbres rechazados.",
+        ],
+        "requerimientos_especiales": ["Compatibilidad con PAC autorizado"],
+        "criterios_aceptacion": ["Se timbran CFDI de prueba sin errores."],
+    }
+
+    html = _build_html_document(content)
+
+    assert "REQ-001 - Ajuste de timbrado" in html
+    assert "MEJORA" in html
+    assert "2024-06-03" in html
+    assert "09:00" in html and "10:30" in html
+    assert "<br />" in html  # salto de línea convertido en etiqueta HTML
+    assert "<li>El sistema debe recalcular impuestos antes de timbrar.</li>" in html
+    assert "&nbsp;" not in html  # todos los campos con datos deben evitar el espacio duro


### PR DESCRIPTION
## Summary
- align `card_generation.html` with the requested table structure while keeping the dynamic placeholders
- note the inline-style adjustment in the existing 0.8.2 changelog entry

## Testing
- pytest tests/test_cards_ai_view_html.py

------
https://chatgpt.com/codex/tasks/task_e_690259b210f0832cb42083eb1263a1fb