### PR TITLE
Send extended RAG context as assistant message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.9.2] - 2024-06-07
+### Changed
+- El servicio de IA ahora envía el contexto histórico como mensaje `assistant` previo al usuario para simular lineamientos previos sin contaminar el prompt principal.
+- Se añadió un formateo dedicado para el bloque de contexto extendido que instruye al modelo a utilizar la información solo como referencia técnica.
+- Las pruebas de `CardAIService` se actualizaron para validar la nueva estructura de mensajes enviada al modelo.
+
 ## [0.9.1] - 2024-06-06
 ### Added
 - Botones en el historial de resultados para exportar cada `cards_ai_output` en JSON, Markdown, DOCX o HTML sin abandonar la ventana.

--- a/tests/test_card_ai_service.py
+++ b/tests/test_card_ai_service.py
@@ -350,7 +350,7 @@ def test_generate_document_sends_system_prompt_first() -> None:
 
 
 def test_generate_document_injects_retrieved_context() -> None:
-    """The user prompt should include recovered context and store titles in the output."""
+    """The conversation should include recovered context and store titles in the output."""
 
     captured: Dict[str, object] = {}
 
@@ -384,9 +384,11 @@ def test_generate_document_injects_retrieved_context() -> None:
     payload_sent = captured.get("payload")
     assert isinstance(payload_sent, dict)
     messages = payload_sent["messages"]  # type: ignore[index]
-    user_content = messages[1]["content"]
-    assert "Casos previos similares" in user_content
-    assert "Título: Demo previo" in user_content
+    assert messages[0]["role"] == "system"
+    assert messages[1]["role"] == "assistant"
+    assert "Contexto extendido" in messages[1]["content"]
+    assert "Título: Demo previo" in messages[1]["content"]
+    assert messages[2]["role"] == "user"
     assert context_service.receivedQueries[0].startswith("EA-172")
     assert result.output.content["usados_como_contexto"] == context_service.contextTitles
 


### PR DESCRIPTION
## Summary
- format the retrieved RAG context as a dedicated assistant message ahead of the user request
- add a helper to compose the extended context block while keeping the user prompt unchanged
- update the CardAI service tests to expect the new message flow and wording

## Testing
- pytest tests/test_card_ai_service.py

------
https://chatgpt.com/codex/tasks/task_e_690293500694832caabeb992577b71c4