### PR TITLE
Handle markdown fenced JSON responses from LLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.9.3] - 2024-06-07
+### Fixed
+- `CardAIService` ahora limpia los cercos de código Markdown (por ejemplo, bloques iniciados con `````json```) antes de intentar decodificar el JSON devuelto por el LLM.
+- Se agregó una prueba unitaria que garantiza la compatibilidad con respuestas cercadas.
+
 ## [0.9.2] - 2024-06-07
 ### Changed
 - El servicio de IA ahora envía el contexto histórico como mensaje `assistant` previo al usuario para simular lineamientos previos sin contaminar el prompt principal.


### PR DESCRIPTION
## Summary
- strip markdown code fences from LLM outputs before decoding the JSON payload in CardAIService
- add coverage ensuring the service accepts fenced JSON responses and document the fix in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6902a0644c6c832c97b6795546f2a2b4