### PR TITLE
Add preferred AI output workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.9.4] - 2024-06-08
+### Added
+- Campo `is_best` en `cards_ai_outputs` con opción para marcar desde el historial la mejor respuesta y resaltar las tarjetas con DDE generada en la cuadrícula principal.
+- Filtro "Solo tarjetas con DDE marcada" en la vista de tarjetas para localizar rápidamente las respuestas preferidas.
+- Botón en el historial para marcar una salida como mejor respuesta y reindexar el contexto RAG utilizando únicamente las marcadas.
+
+### Changed
+- El contexto enviado al RAG ahora se compone exclusivamente de los resultados marcados como mejor respuesta.
+- El historial y la tabla de tarjetas destacan visualmente las salidas preferidas.
+
 ## [0.9.3] - 2024-06-07
 ### Fixed
 - `CardAIService` ahora limpia los cercos de código Markdown (por ejemplo, bloques iniciados con `````json```) antes de intentar decodificar el JSON devuelto por el LLM.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## [0.9.4] - 2024-06-08
 ### Added
-- Campo `is_best` en `cards_ai_outputs` con opción para marcar desde el historial la mejor respuesta y resaltar las tarjetas con DDE generada en la cuadrícula principal.
-- Filtro "Solo tarjetas con DDE marcada" en la vista de tarjetas para localizar rápidamente las respuestas preferidas.
-- Botón en el historial para marcar una salida como mejor respuesta y reindexar el contexto RAG utilizando únicamente las marcadas.
+- Campos `is_best` y `dde_generated` en `cards_ai_outputs` con opciones desde el historial para marcar la respuesta preferida o la que generó el DDE y reflejar ambas señales en la cuadrícula principal.
+- Filtros combinados en la vista de tarjetas para localizar tarjetas con o sin mejor respuesta y con o sin DDE generada.
+- Botones en el historial para marcar una salida como mejor respuesta, indicar si generó el DDE y reindexar el contexto RAG utilizando únicamente las marcadas.
 
 ### Changed
 - El contexto enviado al RAG ahora se compone exclusivamente de los resultados marcados como mejor respuesta.
-- El historial y la tabla de tarjetas destacan visualmente las salidas preferidas.
+- El historial y la tabla de tarjetas destacan visualmente las salidas preferidas y las que ya cuentan con DDE generado.
 
 ## [0.9.3] - 2024-06-07
 ### Fixed

--- a/app/controllers/card_ai_controller.py
+++ b/app/controllers/card_ai_controller.py
@@ -27,13 +27,32 @@ class CardAIController:
     def list_cards(self, filters: Dict[str, object]) -> List[CardDTO]:
         """Return cards matching the filters provided by the view."""
 
+        best_selection = None
+        best_filter = (
+            str(filters.get("estadoMejor")).strip().lower() if filters.get("estadoMejor") else ""
+        )
+        if best_filter.startswith("con"):
+            best_selection = True
+        elif best_filter.startswith("sin"):
+            best_selection = False
+
+        dde_generated = None
+        dde_filter = (
+            str(filters.get("estadoDde")).strip().lower() if filters.get("estadoDde") else ""
+        )
+        if dde_filter.startswith("con"):
+            dde_generated = True
+        elif dde_filter.startswith("sin"):
+            dde_generated = False
+
         dto = CardFiltersDTO(
             cardType=str(filters.get("tipo")) if filters.get("tipo") else None,
             status=str(filters.get("status")) if filters.get("status") else None,
             startDate=filters.get("fechaInicio"),
             endDate=filters.get("fechaFin"),
             searchText=str(filters.get("busqueda")) if filters.get("busqueda") else None,
-            bestOnly=bool(filters.get("soloMejor")),
+            bestSelection=best_selection,
+            ddeGenerated=dde_generated,
         )
         try:
             return self._service.list_cards(dto)
@@ -95,6 +114,14 @@ class CardAIController:
 
         try:
             return self._service.mark_output_as_best(output_id)
+        except CardAIServiceError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+    def mark_output_dde_generated(self, output_id: int, generated: bool) -> CardAIOutputDTO:
+        """Toggle the DDE generated flag for the selected output."""
+
+        try:
+            return self._service.set_output_dde_generated(output_id, generated)
         except CardAIServiceError as exc:
             raise RuntimeError(str(exc)) from exc
 

--- a/app/controllers/card_ai_controller.py
+++ b/app/controllers/card_ai_controller.py
@@ -8,6 +8,7 @@ from app.dtos.card_ai_dto import (
     CardAIHistoryEntryDTO,
     CardAIInputDTO,
     CardAIGenerationResultDTO,
+    CardAIOutputDTO,
     CardDTO,
     CardFiltersDTO,
     card_ai_request_from_dict,
@@ -32,6 +33,7 @@ class CardAIController:
             startDate=filters.get("fechaInicio"),
             endDate=filters.get("fechaFin"),
             searchText=str(filters.get("busqueda")) if filters.get("busqueda") else None,
+            bestOnly=bool(filters.get("soloMejor")),
         )
         try:
             return self._service.list_cards(dto)
@@ -85,6 +87,14 @@ class CardAIController:
 
         try:
             self._service.delete_output(output_id)
+        except CardAIServiceError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+    def mark_output_as_best(self, output_id: int) -> CardAIOutputDTO:
+        """Mark the selected output as the preferred document."""
+
+        try:
+            return self._service.mark_output_as_best(output_id)
         except CardAIServiceError as exc:
             raise RuntimeError(str(exc)) from exc
 

--- a/app/daos/card_ai_output_dao.py
+++ b/app/daos/card_ai_output_dao.py
@@ -56,6 +56,7 @@ class CardAIOutputDAO:
                         llm_usage_json NVARCHAR(MAX) NULL,
                         content_json NVARCHAR(MAX) NOT NULL,
                         is_best BIT NOT NULL DEFAULT(0),
+                        dde_generated BIT NOT NULL DEFAULT(0),
                         created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME()
                     );
                     CREATE INDEX ix_cards_ai_outputs_card_id
@@ -65,6 +66,11 @@ class CardAIOutputDAO:
                 BEGIN
                     ALTER TABLE dbo.cards_ai_outputs
                         ADD is_best BIT NOT NULL DEFAULT(0);
+                END
+                IF COL_LENGTH('dbo.cards_ai_outputs', 'dde_generated') IS NULL
+                BEGIN
+                    ALTER TABLE dbo.cards_ai_outputs
+                        ADD dde_generated BIT NOT NULL DEFAULT(0);
                 END
                 """
             )
@@ -108,7 +114,7 @@ class CardAIOutputDAO:
                     "INSERT INTO dbo.cards_ai_outputs "
                     "(card_id, input_id, llm_id, llm_model, llm_usage_json, content_json) "
                     "VALUES (%s, %s, %s, %s, %s, %s);"
-                    "SELECT output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, is_best, created_at "
+                    "SELECT output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, is_best, dde_generated, created_at "
                     "FROM dbo.cards_ai_outputs WHERE output_id = SCOPE_IDENTITY();"
                 ),
                 (card_id, input_id, llm_id, llm_model, usage_json, content_json),
@@ -124,7 +130,7 @@ class CardAIOutputDAO:
             raise CardAIOutputDAOError("No fue posible guardar el resultado generado.") from exc
 
         connection.close()
-        created_at = row[8]
+        created_at = row[9]
         if not isinstance(created_at, datetime):
             created_at = datetime.fromisoformat(str(created_at))
         return CardAIOutputDTO(
@@ -136,6 +142,7 @@ class CardAIOutputDAO:
             llmUsage=json.loads(row[5] or "{}"),
             content=json.loads(row[6] or "{}"),
             isBest=bool(row[7]),
+            ddeGenerated=bool(row[8]),
             createdAt=created_at,
         )
 
@@ -152,7 +159,7 @@ class CardAIOutputDAO:
             cursor = connection.cursor()
             cursor.execute(
                 (
-                    "SELECT TOP (%s) output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, is_best, created_at "
+                    "SELECT TOP (%s) output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, is_best, dde_generated, created_at "
                     "FROM dbo.cards_ai_outputs WHERE card_id = %s ORDER BY created_at DESC, output_id DESC"
                 ),
                 (limit, card_id),
@@ -165,7 +172,7 @@ class CardAIOutputDAO:
         connection.close()
         outputs: List[CardAIOutputDTO] = []
         for row in rows:
-            created_at = row[8]
+            created_at = row[9]
             if not isinstance(created_at, datetime):
                 created_at = datetime.fromisoformat(str(created_at))
             outputs.append(
@@ -178,6 +185,7 @@ class CardAIOutputDAO:
                     llmUsage=json.loads(row[5] or "{}"),
                     content=json.loads(row[6] or "{}"),
                     isBest=bool(row[7]),
+                    ddeGenerated=bool(row[8]),
                     createdAt=created_at,
                 )
             )
@@ -283,7 +291,7 @@ class CardAIOutputDAO:
             )
             cursor.execute(
                 (
-                    "SELECT output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, is_best, created_at "
+                    "SELECT output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, is_best, dde_generated, created_at "
                     "FROM dbo.cards_ai_outputs WHERE output_id = %s"
                 ),
                 (output_id,),
@@ -310,7 +318,7 @@ class CardAIOutputDAO:
         if not updated:
             raise CardAIOutputDAOError("El resultado indicado no existe.")
 
-        created_at = updated[8]
+        created_at = updated[9]
         if not isinstance(created_at, datetime):
             created_at = datetime.fromisoformat(str(created_at))
         return CardAIOutputDTO(
@@ -322,6 +330,66 @@ class CardAIOutputDAO:
             llmUsage=json.loads(updated[5] or "{}"),
             content=json.loads(updated[6] or "{}"),
             isBest=bool(updated[7]),
+            ddeGenerated=bool(updated[8]),
+            createdAt=created_at,
+        )
+
+    def mark_dde_generated(self, output_id: int, generated: bool) -> CardAIOutputDTO:
+        """Toggle the flag that indicates whether the output produced a DDE."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise CardAIOutputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                "UPDATE dbo.cards_ai_outputs SET dde_generated = %s WHERE output_id = %s",
+                (1 if generated else 0, output_id),
+            )
+            if (cursor.rowcount or 0) == 0:
+                connection.rollback()
+                connection.close()
+                raise CardAIOutputDAOError("El resultado indicado no existe.")
+            cursor.execute(
+                (
+                    "SELECT output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, is_best, dde_generated, created_at "
+                    "FROM dbo.cards_ai_outputs WHERE output_id = %s"
+                ),
+                (output_id,),
+            )
+            updated = cursor.fetchone()
+            connection.commit()
+        except CardAIOutputDAOError:
+            raise
+        except Exception as exc:  # pragma: no cover - depende del driver
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise CardAIOutputDAOError("No fue posible actualizar la marca de DDE generada.") from exc
+
+        connection.close()
+
+        if not updated:
+            raise CardAIOutputDAOError("El resultado indicado no existe.")
+
+        created_at = updated[9]
+        if not isinstance(created_at, datetime):
+            created_at = datetime.fromisoformat(str(created_at))
+        return CardAIOutputDTO(
+            outputId=int(updated[0]),
+            cardId=int(updated[1]),
+            inputId=int(updated[2]) if updated[2] is not None else None,
+            llmId=updated[3],
+            llmModel=updated[4],
+            llmUsage=json.loads(updated[5] or "{}"),
+            content=json.loads(updated[6] or "{}"),
+            isBest=bool(updated[7]),
+            ddeGenerated=bool(updated[8]),
             createdAt=created_at,
         )
 

--- a/app/daos/card_ai_output_dao.py
+++ b/app/daos/card_ai_output_dao.py
@@ -55,10 +55,16 @@ class CardAIOutputDAO:
                         llm_model VARCHAR(100) NULL,
                         llm_usage_json NVARCHAR(MAX) NULL,
                         content_json NVARCHAR(MAX) NOT NULL,
+                        is_best BIT NOT NULL DEFAULT(0),
                         created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME()
                     );
                     CREATE INDEX ix_cards_ai_outputs_card_id
                         ON dbo.cards_ai_outputs (card_id DESC, output_id DESC);
+                END
+                IF COL_LENGTH('dbo.cards_ai_outputs', 'is_best') IS NULL
+                BEGIN
+                    ALTER TABLE dbo.cards_ai_outputs
+                        ADD is_best BIT NOT NULL DEFAULT(0);
                 END
                 """
             )
@@ -102,7 +108,7 @@ class CardAIOutputDAO:
                     "INSERT INTO dbo.cards_ai_outputs "
                     "(card_id, input_id, llm_id, llm_model, llm_usage_json, content_json) "
                     "VALUES (%s, %s, %s, %s, %s, %s);"
-                    "SELECT output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, created_at "
+                    "SELECT output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, is_best, created_at "
                     "FROM dbo.cards_ai_outputs WHERE output_id = SCOPE_IDENTITY();"
                 ),
                 (card_id, input_id, llm_id, llm_model, usage_json, content_json),
@@ -118,7 +124,7 @@ class CardAIOutputDAO:
             raise CardAIOutputDAOError("No fue posible guardar el resultado generado.") from exc
 
         connection.close()
-        created_at = row[7]
+        created_at = row[8]
         if not isinstance(created_at, datetime):
             created_at = datetime.fromisoformat(str(created_at))
         return CardAIOutputDTO(
@@ -129,6 +135,7 @@ class CardAIOutputDAO:
             llmModel=row[4],
             llmUsage=json.loads(row[5] or "{}"),
             content=json.loads(row[6] or "{}"),
+            isBest=bool(row[7]),
             createdAt=created_at,
         )
 
@@ -145,7 +152,7 @@ class CardAIOutputDAO:
             cursor = connection.cursor()
             cursor.execute(
                 (
-                    "SELECT TOP (%s) output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, created_at "
+                    "SELECT TOP (%s) output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, is_best, created_at "
                     "FROM dbo.cards_ai_outputs WHERE card_id = %s ORDER BY created_at DESC, output_id DESC"
                 ),
                 (limit, card_id),
@@ -158,7 +165,7 @@ class CardAIOutputDAO:
         connection.close()
         outputs: List[CardAIOutputDTO] = []
         for row in rows:
-            created_at = row[7]
+            created_at = row[8]
             if not isinstance(created_at, datetime):
                 created_at = datetime.fromisoformat(str(created_at))
             outputs.append(
@@ -170,6 +177,7 @@ class CardAIOutputDAO:
                     llmModel=row[4],
                     llmUsage=json.loads(row[5] or "{}"),
                     content=json.loads(row[6] or "{}"),
+                    isBest=bool(row[7]),
                     createdAt=created_at,
                 )
             )
@@ -191,6 +199,7 @@ class CardAIOutputDAO:
                     "SELECT TOP (%s) o.output_id, o.card_id, COALESCE(c.title, ''), o.content_json "
                     "FROM dbo.cards_ai_outputs o "
                     "INNER JOIN dbo.cards c ON c.id = o.card_id "
+                    "WHERE o.is_best = 1 "
                     "ORDER BY o.output_id DESC"
                 ),
                 (limit,),
@@ -246,4 +255,73 @@ class CardAIOutputDAO:
 
         if affected == 0:
             raise CardAIOutputDAOError("El resultado solicitado no existe o ya fue eliminado.")
+
+    def mark_best_output(self, output_id: int) -> CardAIOutputDTO:
+        """Mark the selected output as the preferred answer for its card."""
+
+        self._ensure_schema()
+        try:
+            connection = self._connection_factory()
+        except DatabaseConnectorError as exc:  # pragma: no cover
+            raise CardAIOutputDAOError(str(exc)) from exc
+
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                "SELECT card_id FROM dbo.cards_ai_outputs WHERE output_id = %s",
+                (output_id,),
+            )
+            row = cursor.fetchone()
+            if not row:
+                connection.close()
+                raise CardAIOutputDAOError("El resultado indicado no existe.")
+            card_id = int(row[0])
+
+            cursor.execute(
+                "UPDATE dbo.cards_ai_outputs SET is_best = CASE WHEN output_id = %s THEN 1 ELSE 0 END WHERE card_id = %s",
+                (output_id, card_id),
+            )
+            cursor.execute(
+                (
+                    "SELECT output_id, card_id, input_id, llm_id, llm_model, llm_usage_json, content_json, is_best, created_at "
+                    "FROM dbo.cards_ai_outputs WHERE output_id = %s"
+                ),
+                (output_id,),
+            )
+            updated = cursor.fetchone()
+            connection.commit()
+        except CardAIOutputDAOError:
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise
+        except Exception as exc:  # pragma: no cover - depende del driver
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            connection.close()
+            raise CardAIOutputDAOError("No fue posible marcar el resultado como mejor respuesta.") from exc
+
+        connection.close()
+
+        if not updated:
+            raise CardAIOutputDAOError("El resultado indicado no existe.")
+
+        created_at = updated[8]
+        if not isinstance(created_at, datetime):
+            created_at = datetime.fromisoformat(str(created_at))
+        return CardAIOutputDTO(
+            outputId=int(updated[0]),
+            cardId=int(updated[1]),
+            inputId=int(updated[2]) if updated[2] is not None else None,
+            llmId=updated[3],
+            llmModel=updated[4],
+            llmUsage=json.loads(updated[5] or "{}"),
+            content=json.loads(updated[6] or "{}"),
+            isBest=bool(updated[7]),
+            createdAt=created_at,
+        )
 

--- a/app/daos/card_dao.py
+++ b/app/daos/card_dao.py
@@ -46,30 +46,37 @@ class CardDAO:
         params: List[object] = []
 
         if filters.cardType:
-            conditions.append("COALESCE(group_name, '') = %s")
+            conditions.append("COALESCE(c.group_name, '') = %s")
             params.append(filters.cardType)
         if filters.status:
-            conditions.append("COALESCE(status, '') = %s")
+            conditions.append("COALESCE(c.status, '') = %s")
             params.append(filters.status)
         if filters.startDate:
-            conditions.append("created_at >= %s")
+            conditions.append("c.created_at >= %s")
             params.append(int(filters.startDate.timestamp()))
         if filters.endDate:
-            conditions.append("created_at <= %s")
+            conditions.append("c.created_at <= %s")
             params.append(int(filters.endDate.timestamp()))
         if filters.searchText:
-            conditions.append("(title LIKE %s OR COALESCE(description,'') LIKE %s OR COALESCE(ticket_id,'') LIKE %s)")
+            conditions.append(
+                "(c.title LIKE %s OR COALESCE(c.description,'') LIKE %s OR COALESCE(c.ticket_id,'') LIKE %s)"
+            )
             like_token = f"%{filters.searchText}%"
             params.extend([like_token, like_token, like_token])
+        if filters.bestOnly:
+            conditions.append(
+                "EXISTS (SELECT 1 FROM dbo.cards_ai_outputs o WHERE o.card_id = c.id AND o.is_best = 1)"
+            )
 
         where_clause = " WHERE " + " AND ".join(conditions) if conditions else ""
 
         sql = (
-            "SELECT TOP (%s) id, title, COALESCE(group_name, ''), COALESCE(status,''),"
-            " created_at, updated_at, COALESCE(ticket_id,''), COALESCE(branch_key,'')"
-            " FROM dbo.cards"
+            "SELECT TOP (%s) c.id, c.title, COALESCE(c.group_name, ''), COALESCE(c.status,''),"
+            " c.created_at, c.updated_at, COALESCE(c.ticket_id,''), COALESCE(c.branch_key,''),"
+            " CASE WHEN EXISTS (SELECT 1 FROM dbo.cards_ai_outputs o WHERE o.card_id = c.id AND o.is_best = 1) THEN 1 ELSE 0 END"
+            " FROM dbo.cards c"
             f"{where_clause}"
-            " ORDER BY COALESCE(updated_at, created_at) DESC"
+            " ORDER BY COALESCE(c.updated_at, c.created_at) DESC"
         )
 
         params = [limit] + params
@@ -97,6 +104,7 @@ class CardDAO:
                     updatedAt=updated_at,
                     ticketId=str(row[6] or ""),
                     branchKey=str(row[7] or ""),
+                    hasBestSelection=bool(row[8]),
                 )
             )
         return cards

--- a/app/dtos/card_ai_dto.py
+++ b/app/dtos/card_ai_dto.py
@@ -19,6 +19,7 @@ class CardDTO:
     updatedAt: Optional[datetime]
     ticketId: str
     branchKey: str
+    hasBestSelection: bool = False
 
 
 @dataclass
@@ -30,6 +31,7 @@ class CardFiltersDTO:
     startDate: Optional[datetime] = None
     endDate: Optional[datetime] = None
     searchText: Optional[str] = None
+    bestOnly: bool = False
 
 
 @dataclass
@@ -62,6 +64,7 @@ class CardAIOutputDTO:
     llmUsage: Dict[str, Any]
     content: Dict[str, Any]
     createdAt: datetime
+    isBest: bool
 
 
 @dataclass

--- a/app/dtos/card_ai_dto.py
+++ b/app/dtos/card_ai_dto.py
@@ -20,6 +20,7 @@ class CardDTO:
     ticketId: str
     branchKey: str
     hasBestSelection: bool = False
+    hasDdeGenerated: bool = False
 
 
 @dataclass
@@ -31,7 +32,8 @@ class CardFiltersDTO:
     startDate: Optional[datetime] = None
     endDate: Optional[datetime] = None
     searchText: Optional[str] = None
-    bestOnly: bool = False
+    bestSelection: Optional[bool] = None
+    ddeGenerated: Optional[bool] = None
 
 
 @dataclass
@@ -65,6 +67,7 @@ class CardAIOutputDTO:
     content: Dict[str, Any]
     createdAt: datetime
     isBest: bool
+    ddeGenerated: bool
 
 
 @dataclass

--- a/app/services/card_ai_service.py
+++ b/app/services/card_ai_service.py
@@ -148,6 +148,14 @@ class CardAIService:
 
         return updated
 
+    def set_output_dde_generated(self, output_id: int, generated: bool) -> CardAIOutputDTO:
+        """Update the flag that tracks whether the output produced a DDE."""
+
+        try:
+            return self._output_dao.mark_dde_generated(output_id, generated)
+        except CardAIOutputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
     def save_draft(self, payload: CardAIRequestDTO) -> CardAIInputDTO:
         """Persist the provided data as draft without contacting the LLM."""
 

--- a/app/services/card_ai_service.py
+++ b/app/services/card_ai_service.py
@@ -34,6 +34,7 @@ from app.dtos.card_ai_dto import (
     CardAIInputDTO,
     CardAIRequestDTO,
     CardAIGenerationResultDTO,
+    CardAIOutputDTO,
     CardDTO,
     CardFiltersDTO,
 )
@@ -130,6 +131,22 @@ class CardAIService:
             self._output_dao.delete_output(output_id)
         except CardAIOutputDAOError as exc:
             raise CardAIServiceError(str(exc)) from exc
+
+    def mark_output_as_best(self, output_id: int) -> CardAIOutputDTO:
+        """Flag an output as the preferred response for its card."""
+
+        try:
+            updated = self._output_dao.mark_best_output(output_id)
+        except CardAIOutputDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        if self._context_service:
+            try:
+                self._context_service.index_from_database()
+            except Exception as exc:  # pragma: no cover - depende de servicios opcionales
+                logger.warning("No fue posible reindexar el contexto tras marcar favorito: %s", exc)
+
+        return updated
 
     def save_draft(self, payload: CardAIRequestDTO) -> CardAIInputDTO:
         """Persist the provided data as draft without contacting the LLM."""

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -444,6 +444,7 @@ CREATE TABLE dbo.cards_ai_outputs (
     llm_usage_json NVARCHAR(MAX) NULL,
     content_json NVARCHAR(MAX) NOT NULL,
     is_best BIT NOT NULL DEFAULT(0),
+    dde_generated BIT NOT NULL DEFAULT(0),
     created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
     CONSTRAINT fk_cards_ai_outputs_card FOREIGN KEY (card_id) REFERENCES dbo.cards(id) ON DELETE CASCADE,
     CONSTRAINT fk_cards_ai_outputs_input FOREIGN KEY (input_id) REFERENCES dbo.cards_ai_inputs(input_id) ON DELETE SET NULL

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -443,6 +443,7 @@ CREATE TABLE dbo.cards_ai_outputs (
     llm_model VARCHAR(100) NULL,
     llm_usage_json NVARCHAR(MAX) NULL,
     content_json NVARCHAR(MAX) NOT NULL,
+    is_best BIT NOT NULL DEFAULT(0),
     created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
     CONSTRAINT fk_cards_ai_outputs_card FOREIGN KEY (card_id) REFERENCES dbo.cards(id) ON DELETE CASCADE,
     CONSTRAINT fk_cards_ai_outputs_input FOREIGN KEY (input_id) REFERENCES dbo.cards_ai_inputs(input_id) ON DELETE SET NULL

--- a/tests/test_card_ai_service.py
+++ b/tests/test_card_ai_service.py
@@ -101,6 +101,8 @@ class FakeOutputDAO:
         self._next_id = 1
         self.deleted: List[int] = []
         self.fail_on_delete = False
+        self.fail_on_mark = False
+        self.marked_best: List[int] = []
 
     def create_output(
         self,
@@ -122,6 +124,7 @@ class FakeOutputDAO:
         dto.llmUsage = llm_usage
         dto.content = content
         dto.createdAt = datetime.now(timezone.utc)
+        dto.isBest = False
         self.created.append(dto)
         return dto
 
@@ -135,6 +138,19 @@ class FakeOutputDAO:
             raise CardAIOutputDAOError("boom")
         self.deleted.append(output_id)
 
+    def mark_best_output(self, output_id: int):
+        """Flag the provided output identifier as the preferred one."""
+
+        if self.fail_on_mark:
+            raise CardAIOutputDAOError("boom")
+        dto = next((item for item in self.created if item.outputId == output_id), None)
+        if not dto:
+            raise CardAIOutputDAOError("missing")
+        for item in self.created:
+            item.isBest = item.outputId == output_id
+        self.marked_best.append(output_id)
+        return dto
+
 
 class FakeContextService:
     """Provide deterministic context snippets for the prompt builder tests."""
@@ -143,10 +159,15 @@ class FakeContextService:
         self.receivedQueries: List[str] = []
         self.contextText = "Título: Demo previo\nDescripción: Caso histórico"
         self.contextTitles = ["EA-100 Ajuste de vencimientos"]
+        self.reindexed = 0
 
     def search_context(self, query: str, limit: int = 3):
         self.receivedQueries.append(query)
         return self.contextText, self.contextTitles
+
+    def index_from_database(self, limit: int = 500):  # pragma: no cover - usado indirectamente
+        self.reindexed += 1
+        return self.reindexed
 
 
 class FakeResponse:
@@ -503,3 +524,51 @@ def test_generate_document_fails_when_system_prompt_missing(tmp_path) -> None:
         service.generate_document(payload)
 
     assert "prompt de sistema" in str(excinfo.value)
+
+
+def test_mark_output_as_best_reindexes_context() -> None:
+    """Selecting a preferred result should update the DAO and reindex context."""
+
+    fake_input = FakeInputDAO()
+    fake_output = FakeOutputDAO()
+    context_service = FakeContextService()
+    service = CardAIService(
+        FakeCardDAO(),
+        fake_input,
+        fake_output,
+        http_post=successful_http_post,
+        context_service=context_service,
+    )
+
+    payload = CardAIRequestDTO(
+        cardId=1,
+        tipo="INCIDENCIA",
+        descripcion="Descripción",
+        analisis="",
+        recomendaciones="",
+        cosasPrevenir="",
+        infoAdicional="",
+    )
+
+    result = service.generate_document(payload)
+    updated = service.mark_output_as_best(result.output.outputId)
+
+    assert updated.isBest is True
+    assert fake_output.marked_best == [result.output.outputId]
+    assert context_service.reindexed == 1
+
+
+def test_mark_output_as_best_wraps_dao_errors() -> None:
+    """DAO failures while marking the preferred result should bubble up as service errors."""
+
+    fake_output = FakeOutputDAO()
+    fake_output.fail_on_mark = True
+    service = CardAIService(
+        FakeCardDAO(),
+        FakeInputDAO(),
+        fake_output,
+        http_post=successful_http_post,
+    )
+
+    with pytest.raises(CardAIServiceError):
+        service.mark_output_as_best(1)


### PR DESCRIPTION
## Summary
- allow marking stored AI outputs as preferred using the new `is_best` flag and expose it through the DAO, DTOs, and service
- highlight and filter cards with a preferred DDE/HU in the Tkinter view while restricting RAG context to the curated outputs
- extend unit tests and documentation to cover the preferred-output workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6902a56acf54832ca970053abd53c098