### PR TITLE
feat: migrate DDE generation to OpenAI

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,31 @@
+# Archivo de ejemplo para configurar variables de entorno durante las pruebas locales.
+# Copia este contenido a un archivo .env (que está ignorado por git) y reemplaza los valores
+# de ejemplo con los datos reales de tu entorno.
+
+# --- Configuración de OpenAI ---
+OPENAI_API_KEY=sk-tu_api_key_de_pruebas
+# El cliente utiliza esta URL por defecto, define la variable solo si deseas apuntar a otro endpoint.
+OPENAI_API_URL=https://api.openai.com/v1/chat/completions
+# Modelo por defecto cuando no se especifica "modo_prueba" o se deja en False.
+OPENAI_MODEL=gpt-4-turbo
+# Ajustes opcionales del modelo que el servicio leerá si están presentes.
+LM_TEMPERATURE=0.35
+LM_TOP_P=0.9
+LM_MAX_TOKENS=10000
+# Ruta al prompt corporativo en formato YAML.
+LM_SYSTEM_PROMPT_PATH=app/prompts/system_prompt.yaml
+
+# --- Conexión a SQL Server ---
+# Cadena de conexión utilizada por los DAOs de la aplicación.
+BRANCH_HISTORY_DB_URL=Driver={ODBC Driver 17 for SQL Server};Server=localhost;Database=BranchHistory;UID=usuario;PWD=contrasena
+# Backend esperado; usa "sqlserver" para conservar el comportamiento actual.
+BRANCH_HISTORY_BACKEND=sqlserver
+
+# --- Preferencias de la aplicación de escritorio ---
+WT_WINDOW_WIDTH=1920
+WT_WINDOW_HEIGHT=1080
+WT_WINDOW_X=0
+WT_WINDOW_Y=0
+# Directorio de datos del navegador que el grabador usará cuando automatiza Chrome.
+WT_USER_DATA_DIR=C:\\Users\\tu_usuario\\AppData\\Local\\Google\\Chrome\\User Data
+WT_PROFILE_DIR=Default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - `CardAIService` ahora consume la API oficial de OpenAI con selección de modelo `gpt-4o-mini`/`gpt-4-turbo` vía `modo_prueba` y maneja los errores de red y límites con excepciones claras.
 - Se actualizaron las pruebas unitarias para stubear las llamadas a OpenAI y validar el modelo seleccionado en modo de prueba.
+- El generador DDE permite controlar vía `usarRga` si se recupera y adjunta el contexto RGA, dejando el valor predeterminado en `False`.
 
 ### Added
 - Cliente `generar_dde` basado en `openai` que construye el prompt YAML corporativo, valida el JSON de salida y ofrece ejemplo de uso.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 - Cliente `generar_dde` basado en `openai` que construye el prompt YAML corporativo, valida el JSON de salida y ofrece ejemplo de uso.
+- Archivo `.env.test.example` con valores de referencia para configurar las variables de entorno requeridas durante las pruebas locales.
 
 ## [0.9.4] - 2024-06-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# [0.10.0] - 2024-06-09
+### Changed
+- `CardAIService` ahora consume la API oficial de OpenAI con selección de modelo `gpt-4o-mini`/`gpt-4-turbo` vía `modo_prueba` y maneja los errores de red y límites con excepciones claras.
+- Se actualizaron las pruebas unitarias para stubear las llamadas a OpenAI y validar el modelo seleccionado en modo de prueba.
+
+### Added
+- Cliente `generar_dde` basado en `openai` que construye el prompt YAML corporativo, valida el JSON de salida y ofrece ejemplo de uso.
+
 ## [0.9.4] - 2024-06-08
 ### Added
 - Campos `is_best` y `dde_generated` en `cards_ai_outputs` con opciones desde el historial para marcar la respuesta preferida o la que generó el DDE y reflejar ambas señales en la cuadrícula principal.

--- a/app/config/ai_config.py
+++ b/app/config/ai_config.py
@@ -1,4 +1,4 @@
-"""Configuration helper for the local language model endpoint."""
+"""Configuration helper for the OpenAI chat completions endpoint."""
 
 from __future__ import annotations
 
@@ -12,8 +12,8 @@ from typing import Mapping, MutableMapping, Optional
 class AIConfiguration:
     """Resolve connection parameters for the AI generation endpoint."""
 
-    DEFAULT_URL: str = "http://127.0.0.1:1234/v1/chat/completions"
-    DEFAULT_MODEL: str = "qwen/qwen2.5-vl-7b"
+    DEFAULT_URL: str = "https://api.openai.com/v1/chat/completions"
+    DEFAULT_MODEL: str = "gpt-4-turbo"
     DEFAULT_TEMPERATURE: float = 0.35
     DEFAULT_TOP_P: float = 0.9
     DEFAULT_MAX_TOKENS: int = 10000
@@ -31,17 +31,17 @@ class AIConfiguration:
     def get_api_url(self) -> str:
         """Return the base URL for the chat completions endpoint."""
 
-        return self._environ.get("LM_URL", self.DEFAULT_URL).strip() or self.DEFAULT_URL
+        return self._environ.get("OPENAI_API_URL", self.DEFAULT_URL).strip() or self.DEFAULT_URL
 
     def get_model_name(self) -> str:
         """Return the model identifier provided to the LLM endpoint."""
 
-        return self._environ.get("LM_MODEL", self.DEFAULT_MODEL).strip() or self.DEFAULT_MODEL
+        return self._environ.get("OPENAI_MODEL", self.DEFAULT_MODEL).strip() or self.DEFAULT_MODEL
 
     def get_api_key(self) -> Optional[str]:
         """Expose the optional API key forwarded as bearer token."""
 
-        token = self._environ.get("LM_API_KEY", "").strip()
+        token = self._environ.get("OPENAI_API_KEY", "").strip()
         return token or None
 
     def get_temperature(self) -> float:

--- a/app/controllers/card_ai_controller.py
+++ b/app/controllers/card_ai_controller.py
@@ -72,8 +72,14 @@ class CardAIController:
         """Trigger a new generation and persist the resulting document."""
 
         dto = card_ai_request_from_dict(payload)
+        modo_prueba_raw = payload.get("modoPrueba")
+        modo_prueba = False
+        if isinstance(modo_prueba_raw, bool):
+            modo_prueba = modo_prueba_raw
+        elif isinstance(modo_prueba_raw, str):
+            modo_prueba = modo_prueba_raw.strip().lower() in {"true", "1", "si", "sí"}
         try:
-            return self._service.generate_document(dto)
+            return self._service.generate_document(dto, modo_prueba=modo_prueba)
         except CardAIServiceError as exc:
             raise RuntimeError(str(exc)) from exc
 

--- a/app/controllers/card_ai_controller.py
+++ b/app/controllers/card_ai_controller.py
@@ -78,8 +78,20 @@ class CardAIController:
             modo_prueba = modo_prueba_raw
         elif isinstance(modo_prueba_raw, str):
             modo_prueba = modo_prueba_raw.strip().lower() in {"true", "1", "si", "sí"}
+
+        usar_rga_raw = payload.get("usarRga")
+        usar_rga = False
+        if isinstance(usar_rga_raw, bool):
+            usar_rga = usar_rga_raw
+        elif isinstance(usar_rga_raw, str):
+            usar_rga = usar_rga_raw.strip().lower() in {"true", "1", "si", "sí"}
+
         try:
-            return self._service.generate_document(dto, modo_prueba=modo_prueba)
+            return self._service.generate_document(
+                dto,
+                modo_prueba=modo_prueba,
+                usar_rga=usar_rga,
+            )
         except CardAIServiceError as exc:
             raise RuntimeError(str(exc)) from exc
 

--- a/app/services/card_ai_service.py
+++ b/app/services/card_ai_service.py
@@ -330,7 +330,10 @@ class CardAIService:
         return self._openai_client
 
     def generate_document(
-        self, payload: CardAIRequestDTO, modo_prueba: bool = False
+        self,
+        payload: CardAIRequestDTO,
+        modo_prueba: bool = False,
+        usar_rga: bool = False,
     ) -> CardAIGenerationResultDTO:
         """Persist the prompt, invoke the LLM and store the resulting JSON."""
 
@@ -358,7 +361,7 @@ class CardAIService:
         prompt = self._build_user_prompt(payload.tipo, titulo, payload)
         context_text = ""
         context_titles: List[str] = []
-        if self._context_service:
+        if usar_rga and self._context_service:
             query_parts = [
                 titulo,
                 payload.descripcion or "",
@@ -384,7 +387,7 @@ class CardAIService:
         except ValueError as exc:
             raise CardAIServiceError("El modelo no devolvió un JSON válido.") from exc
 
-        if context_titles:
+        if usar_rga and context_titles:
             content_json["usados_como_contexto"] = context_titles
 
         try:
@@ -423,7 +426,10 @@ class CardAIService:
         return cleaned.strip()
 
     def regenerate_from_input(
-        self, input_id: int, modo_prueba: bool = False
+        self,
+        input_id: int,
+        modo_prueba: bool = False,
+        usar_rga: bool = False,
     ) -> CardAIGenerationResultDTO:
         """Trigger a new generation using the stored input fields."""
 
@@ -445,7 +451,11 @@ class CardAIService:
             infoAdicional=input_dto.infoAdicional,
             forceSaveInputs=True,
         )
-        return self.generate_document(payload, modo_prueba=modo_prueba)
+        return self.generate_document(
+            payload,
+            modo_prueba=modo_prueba,
+            usar_rga=usar_rga,
+        )
 
     def _load_system_prompt_from_file(self) -> str:
         """Read the corporate system prompt from the configured file path."""

--- a/app/services/openai_dde_client.py
+++ b/app/services/openai_dde_client.py
@@ -1,0 +1,155 @@
+"""Helper for generating DDE documents using the official OpenAI client."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict
+
+try:  # pragma: no cover - habilita ejecutar herramientas sin la dependencia instalada
+    from openai import APIConnectionError, APIError, APITimeoutError, BadRequestError, OpenAI, RateLimitError
+except ModuleNotFoundError:  # pragma: no cover
+    class APIConnectionError(RuntimeError):
+        """Fallback error used when the OpenAI SDK is missing."""
+
+    class APITimeoutError(RuntimeError):
+        """Fallback error used when the OpenAI SDK is missing."""
+
+    class APIError(RuntimeError):
+        """Fallback error used when the OpenAI SDK is missing."""
+
+    class BadRequestError(RuntimeError):
+        """Fallback error used when the OpenAI SDK is missing."""
+
+    class RateLimitError(RuntimeError):
+        """Fallback error used when the OpenAI SDK is missing."""
+
+    class OpenAI:  # type: ignore[override]
+        """Minimal stand-in that raises informative errors when used."""
+
+        def __init__(self, *_args, **_kwargs) -> None:
+            raise RuntimeError(
+                "La dependencia 'openai' no está instalada. Añádela al entorno antes de llamar a generar_dde."
+            )
+
+from app.config.ai_config import AIConfiguration
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _load_system_prompt(config: AIConfiguration) -> str:
+    """Read the corporate YAML prompt content defined for DDE generation."""
+
+    prompt_path = Path(config.get_system_prompt_path()).expanduser()
+    if not prompt_path.is_absolute():
+        prompt_path = Path.cwd() / prompt_path
+
+    try:
+        content = prompt_path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"No se encontró el archivo de prompt de sistema en '{prompt_path}'."
+        ) from exc
+    except OSError as exc:
+        raise RuntimeError(
+            f"Ocurrió un error al leer el prompt de sistema en '{prompt_path}'."
+        ) from exc
+
+    if not content:
+        raise RuntimeError(
+            f"El archivo de prompt de sistema '{prompt_path}' está vacío y no puede utilizarse."
+        )
+    return content
+
+
+def _ensure_openai_client(config: AIConfiguration) -> OpenAI:
+    """Instantiate an OpenAI client using the configured API key."""
+
+    api_key = config.get_api_key()
+    if not api_key:
+        raise RuntimeError(
+            "No se encontró la variable de entorno OPENAI_API_KEY requerida para generar DDE."
+        )
+    return OpenAI(api_key=api_key)
+
+
+def _render_user_prompt(datos: Dict[str, object]) -> str:
+    """Format the provided DDE fields as a user prompt for the model."""
+
+    lines = ["Genera un documento DDE en JSON estricto siguiendo el formato corporativo."]
+    lines.append("Datos proporcionados para el caso actual:")
+    for clave, valor in datos.items():
+        if valor is None:
+            continue
+        texto = str(valor).strip()
+        if not texto:
+            continue
+        lines.append(f"- {clave}: {texto}")
+    return "\n".join(lines)
+
+
+def generar_dde(datos: Dict[str, object], modo_prueba: bool = False) -> str:
+    """Generar un documento DDE utilizando los modelos GPT-4o de OpenAI."""
+
+    config = AIConfiguration()
+    system_prompt = _load_system_prompt(config)
+    client = _ensure_openai_client(config)
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": _render_user_prompt(datos)},
+    ]
+
+    payload = {
+        "model": "gpt-4o-mini" if modo_prueba else "gpt-4-turbo",
+        "messages": messages,
+        "temperature": config.get_temperature(),
+        "top_p": config.get_top_p(),
+        "max_tokens": config.get_max_tokens(),
+    }
+
+    try:
+        completion = client.chat.completions.create(timeout=180, **payload)
+    except (APITimeoutError, APIConnectionError) as exc:  # pragma: no cover - errores de red
+        LOGGER.warning("No fue posible contactar al endpoint de OpenAI: %s", exc)
+        raise RuntimeError("No fue posible contactar al endpoint de OpenAI.") from exc
+    except RateLimitError as exc:  # pragma: no cover - depende del límite del entorno
+        LOGGER.warning("Se alcanzó el límite de peticiones permitido por OpenAI: %s", exc)
+        raise RuntimeError("OpenAI alcanzó el límite de peticiones permitido.") from exc
+    except BadRequestError as exc:  # pragma: no cover - entrada inválida
+        LOGGER.warning("OpenAI rechazó la solicitud enviada: %s", exc)
+        raise RuntimeError("La solicitud enviada a OpenAI es inválida.") from exc
+    except APIError as exc:  # pragma: no cover - errores genéricos de la API
+        LOGGER.warning("OpenAI devolvió un error inesperado: %s", exc)
+        raise RuntimeError("OpenAI devolvió un error inesperado.") from exc
+
+    try:
+        contenido = completion.choices[0].message.content or ""
+    except (IndexError, AttributeError) as exc:  # pragma: no cover - defensivo
+        LOGGER.warning("La respuesta de OpenAI no contiene contenido utilizable: %s", exc)
+        raise RuntimeError("La respuesta de OpenAI no contiene contenido utilizable.") from exc
+
+    contenido = contenido.strip()
+    try:
+        json.loads(contenido)
+    except json.JSONDecodeError as exc:
+        LOGGER.warning("La respuesta del modelo no es JSON válido: %s", exc)
+        raise RuntimeError("La respuesta del modelo no es JSON válido.") from exc
+
+    return contenido
+
+
+if __name__ == "__main__":  # pragma: no cover - ejemplo manual
+    ejemplo = {
+        "titulo": "EA-172 Ajuste de vencimientos",
+        "descripcion": "El módulo de cartera no genera los vencimientos al actualizar fechas.",
+        "analisis": "Se detectó que la rutina de cálculo ignora los contratos con pagos parciales.",
+        "recomendaciones": "Agregar validaciones sobre los contratos con pagos vencidos.",
+    }
+    try:
+        resultado = generar_dde(ejemplo, modo_prueba=True)
+        print(resultado)
+    except RuntimeError as error:
+        print(f"Error al generar el DDE: {error}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ MouseInfo==0.1.3
 mss==10.1.0
 numpy==2.3.2
 openpyxl==3.1.5
+openai==1.55.0
 packaging==25.0
 pandas==2.3.2
 pillow==10.4.0


### PR DESCRIPTION
## Summary
- migrate CardAIService and controller to use OpenAI chat completions with optional test mode model selection
- add a reusable generar_dde helper backed by the official openai client and update configuration defaults
- refresh unit tests and dependencies to cover the new OpenAI integration and model selection logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6908d718b5cc832cbfc4089abb18f9e0