### PR TITLE
Add database-driven AI provider configuration and selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Servicio `AIConfigurationService` con sus DAOs (`AISettingsDAO` y `AIProviderDAO`) para resolver proveedores de IA desde SQL Server, incluida la semilla automática de los cuatro proveedores soportados.
 - Selector de proveedor en la captura de DDE/HU que toma el favorito como predeterminado y permite cambiarlo por petición.
 - Compatibilidad con los endpoints locales OpenAI, OpenAI oficial (gpt-4o-mini y gpt-4-turbo) y Mistral desde `CardAIService`, junto con pruebas unitarias para el flujo remoto.
+- Tabla `dbo.ai_request_logs` y auditoría automática en `CardAIService` que guarda cada petición/respuesta y marca cuando el JSON devuelto no es válido.
 
 ### Changed
 - `CardAIService` ahora consulta la configuración persistida, evita enviar contexto RAG cuando el proveedor no es local y usa el SDK oficial de OpenAI o las rutas HTTP correspondientes según el caso.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.10.0] - 2024-06-09
+### Added
+- Servicio `AIConfigurationService` con sus DAOs (`AISettingsDAO` y `AIProviderDAO`) para resolver proveedores de IA desde SQL Server, incluida la semilla automática de los cuatro proveedores soportados.
+- Selector de proveedor en la captura de DDE/HU que toma el favorito como predeterminado y permite cambiarlo por petición.
+- Compatibilidad con los endpoints locales OpenAI, OpenAI oficial (gpt-4o-mini y gpt-4-turbo) y Mistral desde `CardAIService`, junto con pruebas unitarias para el flujo remoto.
+
+### Changed
+- `CardAIService` ahora consulta la configuración persistida, evita enviar contexto RAG cuando el proveedor no es local y usa el SDK oficial de OpenAI o las rutas HTTP correspondientes según el caso.
+- `MainController` inicializa la configuración de IA compartida para inyectarla en el servicio de tarjetas.
+
 ## [0.9.4] - 2024-06-08
 ### Added
 - Campos `is_best` y `dde_generated` en `cards_ai_outputs` con opciones desde el historial para marcar la respuesta preferida o la que generó el DDE y reflejar ambas señales en la cuadrícula principal.

--- a/app/config/ai_config.py
+++ b/app/config/ai_config.py
@@ -12,7 +12,7 @@ from typing import Mapping, MutableMapping, Optional
 class AIConfiguration:
     """Resolve connection parameters for the AI generation endpoint."""
 
-    DEFAULT_URL: str = "http://127.0.0.1:1234/v1/chat/completions"
+    DEFAULT_URL: str = "http://127.0.0.1:1234/v1"
     DEFAULT_MODEL: str = "qwen/qwen2.5-vl-7b"
     DEFAULT_TEMPERATURE: float = 0.35
     DEFAULT_TOP_P: float = 0.9
@@ -29,7 +29,7 @@ class AIConfiguration:
         )
 
     def get_api_url(self) -> str:
-        """Return the base URL for the chat completions endpoint."""
+        """Return the base URL for the language model API."""
 
         return self._environ.get("LM_URL", self.DEFAULT_URL).strip() or self.DEFAULT_URL
 

--- a/app/controllers/card_ai_controller.py
+++ b/app/controllers/card_ai_controller.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 
+from app.dtos.ai_settings_dto import AIProviderRuntimeDTO
 from app.dtos.card_ai_dto import (
     CardAIHistoryEntryDTO,
     CardAIInputDTO,
@@ -56,6 +57,22 @@ class CardAIController:
         )
         try:
             return self._service.list_cards(dto)
+        except CardAIServiceError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+    def list_providers(self) -> List[AIProviderRuntimeDTO]:
+        """Expose the configured AI providers."""
+
+        try:
+            return self._service.list_providers()
+        except CardAIServiceError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+    def get_default_provider_key(self) -> str:
+        """Return the provider key selected by default."""
+
+        try:
+            return self._service.get_default_provider_key()
         except CardAIServiceError as exc:
             raise RuntimeError(str(exc)) from exc
 

--- a/app/controllers/main_controller.py
+++ b/app/controllers/main_controller.py
@@ -17,6 +17,8 @@ from app.controllers.naming_controller import NamingController
 from app.controllers.session_controller import SessionController
 from app.daos.database import DatabaseConnector
 from app.daos.evidence_dao import SessionEvidenceDAO
+from app.daos.ai_provider_dao import AIProviderDAO
+from app.daos.ai_settings_dao import AISettingsDAO
 from app.daos.card_ai_input_dao import CardAIInputDAO
 from app.daos.card_ai_output_dao import CardAIOutputDAO
 from app.daos.card_dao import CardDAO
@@ -25,6 +27,7 @@ from app.daos.session_dao import SessionDAO
 from app.daos.session_pause_dao import SessionPauseDAO
 from app.daos.user_dao import UserDAO
 from app.services.auth_service import AuthService
+from app.services.ai_configuration_service import AIConfigurationService
 from app.services.card_ai_service import CardAIService
 from app.services.browser_service import BrowserService
 from app.services.history_service import HistoryService
@@ -88,10 +91,15 @@ class MainController:
             self._logger.warning("No fue posible preparar el contexto RAG: %s", exc)
             context_service = None
 
+        ai_configuration_service = AIConfigurationService(
+            AISettingsDAO(cards_connector),
+            AIProviderDAO(cards_connector),
+        )
         card_service = CardAIService(
             CardDAO(cards_connector),
             CardAIInputDAO(cards_connector),
             card_output_dao,
+            ai_configuration_service,
             context_service=context_service,
         )
         self.cardsAI = CardAIController(card_service)

--- a/app/controllers/main_controller.py
+++ b/app/controllers/main_controller.py
@@ -18,6 +18,7 @@ from app.controllers.session_controller import SessionController
 from app.daos.database import DatabaseConnector
 from app.daos.evidence_dao import SessionEvidenceDAO
 from app.daos.ai_provider_dao import AIProviderDAO
+from app.daos.ai_request_log_dao import AIRequestLogDAO
 from app.daos.ai_settings_dao import AISettingsDAO
 from app.daos.card_ai_input_dao import CardAIInputDAO
 from app.daos.card_ai_output_dao import CardAIOutputDAO
@@ -83,6 +84,7 @@ class MainController:
 
         cards_connector = DatabaseConnector().connection_factory()
         card_output_dao = CardAIOutputDAO(cards_connector)
+        request_log_dao = AIRequestLogDAO(cards_connector)
         context_service = None
         try:
             context_service = RAGContextService(card_output_dao)
@@ -99,6 +101,7 @@ class MainController:
             CardDAO(cards_connector),
             CardAIInputDAO(cards_connector),
             card_output_dao,
+            request_log_dao,
             ai_configuration_service,
             context_service=context_service,
         )

--- a/app/daos/ai_provider_dao.py
+++ b/app/daos/ai_provider_dao.py
@@ -1,0 +1,189 @@
+"""DAO utilities for the ``dbo.ai_providers`` catalog."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Dict, List
+
+if TYPE_CHECKING:  # pragma: no cover - solo para tipado
+    import pymssql
+
+from app.config.ai_config import AIConfiguration
+from app.dtos.ai_settings_dto import AIProviderRecordDTO
+
+
+class AIProviderDAOError(RuntimeError):
+    """Raised when the provider catalog cannot be accessed."""
+
+
+class AIProviderDAO:
+    """Manage the catalog of AI providers configured in SQL Server."""
+
+    DEFAULT_PROVIDERS: Dict[str, Dict[str, object]] = {
+        "local": {
+            "model_name": "qwen/qwen2.5-vl-7b",
+            "base_url": "http://127.0.0.1:1234/v1",
+            "favorite": True,
+            "extra": {"label": "LM Studio (Local)"},
+        },
+        "openai_mini": {
+            "model_name": "gpt-4o-mini",
+            "favorite": False,
+            "extra": {"label": "OpenAI GPT-4o mini"},
+        },
+        "openai_turbo": {
+            "model_name": "gpt-4-turbo",
+            "favorite": False,
+            "extra": {"label": "OpenAI GPT-4 Turbo"},
+        },
+        "mistral": {
+            "model_name": "mistral-large-latest",
+            "base_url": "https://api.mistral.ai/v1",
+            "favorite": False,
+            "extra": {"label": "Mistral Large"},
+        },
+    }
+
+    def __init__(
+        self,
+        connection_factory: Callable[[], "pymssql.Connection"],
+        configuration: AIConfiguration | None = None,
+    ) -> None:
+        """Persist dependencies required to bootstrap the catalog."""
+
+        self._connection_factory = connection_factory
+        self._configuration = configuration or AIConfiguration()
+        self._schema_ready = False
+
+    def _ensure_schema(self) -> None:
+        """Create the catalog table and seed default providers if needed."""
+
+        if self._schema_ready:
+            return
+
+        connection = self._connection_factory()
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM sys.tables t
+                    INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+                    WHERE t.name = 'ai_providers' AND s.name = 'dbo'
+                )
+                BEGIN
+                    CREATE TABLE dbo.ai_providers (
+                        id INT IDENTITY(1,1) PRIMARY KEY,
+                        provider_key VARCHAR(32) NOT NULL UNIQUE,
+                        base_url NVARCHAR(2048) NULL,
+                        api_key_enc NVARCHAR(MAX) NULL,
+                        org_id NVARCHAR(255) NULL,
+                        model_name NVARCHAR(255) NULL,
+                        extra_json NVARCHAR(MAX) NULL,
+                        updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+                        favorite BIT NOT NULL DEFAULT (0)
+                    );
+                END
+                """
+            )
+            for provider_key, defaults in self.DEFAULT_PROVIDERS.items():
+                cursor.execute(
+                    """
+                    IF NOT EXISTS (
+                        SELECT 1 FROM dbo.ai_providers WHERE provider_key = %s
+                    )
+                    BEGIN
+                        INSERT INTO dbo.ai_providers (
+                            provider_key,
+                            base_url,
+                            model_name,
+                            extra_json,
+                            favorite
+                        )
+                        VALUES (%s, %s, %s, %s, %s);
+                    END
+                    """,
+                    (
+                        provider_key,
+                        provider_key,
+                        defaults.get("base_url")
+                        or (
+                            self._configuration.get_api_url()
+                            if provider_key == "local"
+                            else None
+                        ),
+                        defaults.get("model_name"),
+                        json.dumps(defaults.get("extra", {}), ensure_ascii=False),
+                        1 if defaults.get("favorite") else 0,
+                    ),
+                )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depende del controlador SQL
+            try:
+                connection.rollback()
+            except Exception:  # pragma: no cover - depende del driver
+                pass
+            connection.close()
+            raise AIProviderDAOError("No fue posible preparar la tabla dbo.ai_providers.") from exc
+        finally:
+            try:
+                connection.close()
+            except Exception:  # pragma: no cover - limpieza defensiva
+                pass
+
+        self._schema_ready = True
+
+    def list_providers(self) -> List[AIProviderRecordDTO]:
+        """Return all providers registered in SQL Server."""
+
+        self._ensure_schema()
+        connection = self._connection_factory()
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                SELECT
+                    provider_key,
+                    base_url,
+                    api_key_enc,
+                    org_id,
+                    model_name,
+                    extra_json,
+                    updated_at,
+                    favorite
+                FROM dbo.ai_providers
+                ORDER BY provider_key ASC;
+                """
+            )
+            rows = cursor.fetchall()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            connection.close()
+            raise AIProviderDAOError("No fue posible recuperar los proveedores de IA.") from exc
+
+        connection.close()
+        providers: List[AIProviderRecordDTO] = []
+        for row in rows:
+            extra_raw = row[5] or "{}"
+            try:
+                extra_parsed = json.loads(extra_raw)
+            except json.JSONDecodeError:
+                extra_parsed = {}
+            updated_at = row[6]
+            if isinstance(updated_at, str):
+                updated_at = datetime.fromisoformat(updated_at)
+            providers.append(
+                AIProviderRecordDTO(
+                    providerKey=str(row[0]),
+                    baseUrl=row[1],
+                    apiKeyEncrypted=row[2],
+                    orgId=row[3],
+                    modelName=row[4],
+                    extra=extra_parsed,
+                    updatedAt=updated_at,
+                    favorite=bool(row[7]),
+                )
+            )
+
+        return providers

--- a/app/daos/ai_request_log_dao.py
+++ b/app/daos/ai_request_log_dao.py
@@ -1,0 +1,151 @@
+"""DAO utilities for persisting AI request and response audits."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - solo para tipado
+    import pymssql
+
+from app.dtos.ai_request_log_dto import AIRequestLogDTO
+
+
+class AIRequestLogDAOError(RuntimeError):
+    """Raised when the AI request log cannot be written or read."""
+
+
+class AIRequestLogDAO:
+    """Provide helpers to store and retrieve ``dbo.ai_request_logs`` entries."""
+
+    def __init__(self, connection_factory: Callable[[], "pymssql.Connection"]) -> None:
+        """Persist the connection factory used to access SQL Server."""
+
+        self._connection_factory = connection_factory
+        self._schema_ready = False
+
+    def _ensure_schema(self) -> None:
+        """Create the log table the first time it is requested."""
+
+        if self._schema_ready:
+            return
+
+        connection = self._connection_factory()
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM sys.tables t
+                    INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+                    WHERE t.name = 'ai_request_logs' AND s.name = 'dbo'
+                )
+                BEGIN
+                    CREATE TABLE dbo.ai_request_logs (
+                        log_id BIGINT IDENTITY(1,1) PRIMARY KEY,
+                        card_id BIGINT NULL,
+                        input_id BIGINT NULL,
+                        provider_key VARCHAR(32) NOT NULL,
+                        model_name NVARCHAR(255) NULL,
+                        request_payload NVARCHAR(MAX) NOT NULL,
+                        response_payload NVARCHAR(MAX) NULL,
+                        response_content NVARCHAR(MAX) NULL,
+                        is_valid_json BIT NOT NULL DEFAULT(0),
+                        error_message NVARCHAR(1024) NULL,
+                        created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+                        CONSTRAINT fk_ai_request_logs_card FOREIGN KEY (card_id)
+                            REFERENCES dbo.cards(id) ON DELETE SET NULL,
+                        CONSTRAINT fk_ai_request_logs_input FOREIGN KEY (input_id)
+                            REFERENCES dbo.cards_ai_inputs(input_id) ON DELETE SET NULL
+                    );
+                    CREATE INDEX ix_ai_request_logs_created_at
+                        ON dbo.ai_request_logs (created_at DESC, log_id DESC);
+                END
+                """
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depende del controlador SQL
+            try:
+                connection.rollback()
+            except Exception:  # pragma: no cover - limpieza defensiva
+                pass
+            connection.close()
+            raise AIRequestLogDAOError(
+                "No fue posible preparar la tabla dbo.ai_request_logs."
+            ) from exc
+        finally:
+            try:
+                connection.close()
+            except Exception:  # pragma: no cover - limpieza defensiva
+                pass
+
+        self._schema_ready = True
+
+    def create_log(
+        self,
+        card_id: Optional[int],
+        input_id: Optional[int],
+        provider_key: str,
+        model_name: Optional[str],
+        request_payload: str,
+        response_payload: Optional[str],
+        response_content: Optional[str],
+        is_valid_json: bool,
+        error_message: Optional[str],
+    ) -> AIRequestLogDTO:
+        """Insert a new audit entry and return the stored DTO."""
+
+        self._ensure_schema()
+        connection = self._connection_factory()
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                (
+                    "INSERT INTO dbo.ai_request_logs "
+                    "(card_id, input_id, provider_key, model_name, request_payload, response_payload, response_content, is_valid_json, error_message) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s);"
+                    "SELECT log_id, card_id, input_id, provider_key, model_name, request_payload, response_payload, response_content, is_valid_json, error_message, created_at "
+                    "FROM dbo.ai_request_logs WHERE log_id = SCOPE_IDENTITY();"
+                ),
+                (
+                    card_id,
+                    input_id,
+                    provider_key,
+                    model_name,
+                    request_payload,
+                    response_payload,
+                    response_content,
+                    1 if is_valid_json else 0,
+                    error_message,
+                ),
+            )
+            row = cursor.fetchone()
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depende del controlador SQL
+            try:
+                connection.rollback()
+            except Exception:  # pragma: no cover - limpieza defensiva
+                pass
+            connection.close()
+            raise AIRequestLogDAOError(
+                "No fue posible registrar la bitácora de la petición de IA."
+            ) from exc
+
+        connection.close()
+        created_at = row[10]
+        if not isinstance(created_at, datetime):
+            created_at = datetime.fromisoformat(str(created_at))
+        return AIRequestLogDTO(
+            logId=int(row[0]),
+            cardId=int(row[1]) if row[1] is not None else None,
+            inputId=int(row[2]) if row[2] is not None else None,
+            providerKey=str(row[3]),
+            modelName=row[4],
+            requestPayload=row[5],
+            responsePayload=row[6],
+            responseContent=row[7],
+            isValidJson=bool(row[8]),
+            errorMessage=row[9],
+            createdAt=created_at,
+        )

--- a/app/daos/ai_settings_dao.py
+++ b/app/daos/ai_settings_dao.py
@@ -1,0 +1,140 @@
+"""DAO responsible for loading and preparing AI settings tables."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:  # pragma: no cover - solo para tipado
+    import pymssql
+
+from app.config.ai_config import AIConfiguration
+from app.dtos.ai_settings_dto import AISettingsRecordDTO
+
+
+class AISettingsDAOError(RuntimeError):
+    """Raised when the AI settings table cannot be accessed."""
+
+
+class AISettingsDAO:
+    """Provide helpers to read the ``dbo.ai_settings`` table."""
+
+    def __init__(
+        self,
+        connection_factory: Callable[[], "pymssql.Connection"],
+        configuration: AIConfiguration | None = None,
+    ) -> None:
+        """Store the connection factory and defaults used for bootstrapping."""
+
+        self._connection_factory = connection_factory
+        self._configuration = configuration or AIConfiguration()
+        self._schema_ready = False
+
+    def _ensure_schema(self) -> None:
+        """Create the table and default row the first time it is required."""
+
+        if self._schema_ready:
+            return
+
+        connection = self._connection_factory()
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                IF NOT EXISTS (
+                    SELECT 1
+                    FROM sys.tables t
+                    INNER JOIN sys.schemas s ON s.schema_id = t.schema_id
+                    WHERE t.name = 'ai_settings' AND s.name = 'dbo'
+                )
+                BEGIN
+                    CREATE TABLE dbo.ai_settings (
+                        id INT IDENTITY(1,1) PRIMARY KEY,
+                        active_provider VARCHAR(32) NOT NULL DEFAULT ('local'),
+                        temperature FLOAT NOT NULL DEFAULT (0.35),
+                        max_tokens INT NOT NULL DEFAULT (10000),
+                        timeout_seconds INT NOT NULL DEFAULT (180),
+                        use_rag_local BIT NOT NULL DEFAULT (1),
+                        updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME()
+                    );
+                END
+                """
+            )
+            cursor.execute(
+                """
+                IF NOT EXISTS (SELECT 1 FROM dbo.ai_settings)
+                BEGIN
+                    INSERT INTO dbo.ai_settings (
+                        active_provider,
+                        temperature,
+                        max_tokens,
+                        timeout_seconds,
+                        use_rag_local
+                    )
+                    VALUES (%s, %s, %s, %s, 1);
+                END
+                """,
+                (
+                    "local",
+                    self._configuration.get_temperature(),
+                    self._configuration.get_max_tokens(),
+                    180,
+                ),
+            )
+            connection.commit()
+        except Exception as exc:  # pragma: no cover - depende del controlador SQL
+            try:
+                connection.rollback()
+            except Exception:  # pragma: no cover - depende del driver
+                pass
+            connection.close()
+            raise AISettingsDAOError("No fue posible preparar la tabla dbo.ai_settings.") from exc
+        finally:
+            try:
+                connection.close()
+            except Exception:  # pragma: no cover - limpieza defensiva
+                pass
+
+        self._schema_ready = True
+
+    def get_settings(self) -> AISettingsRecordDTO:
+        """Return the latest AI settings stored in SQL Server."""
+
+        self._ensure_schema()
+        connection = self._connection_factory()
+        try:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                SELECT TOP (1)
+                    active_provider,
+                    temperature,
+                    max_tokens,
+                    timeout_seconds,
+                    use_rag_local,
+                    updated_at
+                FROM dbo.ai_settings
+                ORDER BY updated_at DESC, id DESC;
+                """
+            )
+            row = cursor.fetchone()
+        except Exception as exc:  # pragma: no cover - depende del driver
+            connection.close()
+            raise AISettingsDAOError("No fue posible recuperar la configuración de IA.") from exc
+
+        connection.close()
+        if not row:
+            raise AISettingsDAOError("La tabla dbo.ai_settings no contiene registros válidos.")
+
+        updated_at = row[5]
+        if isinstance(updated_at, str):
+            updated_at = datetime.fromisoformat(updated_at)
+
+        return AISettingsRecordDTO(
+            activeProvider=str(row[0] or "local"),
+            temperature=float(row[1] or self._configuration.get_temperature()),
+            maxTokens=int(row[2] or self._configuration.get_max_tokens()),
+            timeoutSeconds=int(row[3] or 180),
+            useRagLocal=bool(row[4]),
+            updatedAt=updated_at,
+        )

--- a/app/dtos/ai_request_log_dto.py
+++ b/app/dtos/ai_request_log_dto.py
@@ -1,0 +1,24 @@
+"""Data transfer objects for AI request audit records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class AIRequestLogDTO:
+    """Represent a stored AI request/response audit entry."""
+
+    logId: int
+    cardId: Optional[int]
+    inputId: Optional[int]
+    providerKey: str
+    modelName: Optional[str]
+    requestPayload: str
+    responsePayload: Optional[str]
+    responseContent: Optional[str]
+    isValidJson: bool
+    errorMessage: Optional[str]
+    createdAt: datetime

--- a/app/dtos/ai_settings_dto.py
+++ b/app/dtos/ai_settings_dto.py
@@ -1,0 +1,65 @@
+"""Data transfer objects describing AI provider configuration records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Optional
+
+
+@dataclass
+class AIProviderRecordDTO:
+    """Represent a provider row as stored in the database."""
+
+    providerKey: str
+    baseUrl: Optional[str]
+    apiKeyEncrypted: Optional[str]
+    orgId: Optional[str]
+    modelName: Optional[str]
+    extra: Dict[str, object]
+    updatedAt: Optional[datetime]
+    favorite: bool
+
+
+@dataclass
+class AISettingsRecordDTO:
+    """Represent the global AI settings persisted in SQL Server."""
+
+    activeProvider: str
+    temperature: float
+    maxTokens: int
+    timeoutSeconds: int
+    useRagLocal: bool
+    updatedAt: Optional[datetime]
+
+
+@dataclass
+class AIProviderRuntimeDTO:
+    """Expose a decrypted provider ready for runtime consumption."""
+
+    providerKey: str
+    displayName: str
+    baseUrl: Optional[str]
+    apiKey: Optional[str]
+    orgId: Optional[str]
+    modelName: str
+    extra: Dict[str, object]
+    favorite: bool
+
+
+@dataclass
+class ResolvedAIConfigurationDTO:
+    """Aggregate provider and global settings for an invocation."""
+
+    providerKey: str
+    displayName: str
+    baseUrl: Optional[str]
+    apiKey: Optional[str]
+    orgId: Optional[str]
+    modelName: str
+    temperature: float
+    topP: float
+    maxTokens: int
+    timeoutSeconds: int
+    useRagLocal: bool
+    extra: Dict[str, object]

--- a/app/dtos/card_ai_dto.py
+++ b/app/dtos/card_ai_dto.py
@@ -108,6 +108,7 @@ class CardAIRequestDTO:
     recomendaciones: Optional[str]
     cosasPrevenir: Optional[str]
     infoAdicional: Optional[str]
+    providerKey: Optional[str] = None
     forceSaveInputs: bool = False
 
 
@@ -122,6 +123,11 @@ def card_ai_request_from_dict(payload: Dict[str, Any]) -> CardAIRequestDTO:
         recomendaciones=payload.get("recomendaciones"),
         cosasPrevenir=payload.get("cosasPrevenir"),
         infoAdicional=payload.get("infoAdicional"),
+        providerKey=(
+            str(payload.get("providerKey")).strip() or None
+            if payload.get("providerKey") is not None
+            else None
+        ),
         forceSaveInputs=bool(payload.get("forceSaveInputs", False)),
     )
 

--- a/app/services/ai_configuration_service.py
+++ b/app/services/ai_configuration_service.py
@@ -1,0 +1,212 @@
+"""Service that consolidates AI provider configuration data."""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Dict, List, Optional
+
+from app.config.ai_config import AIConfiguration
+from app.daos.ai_provider_dao import AIProviderDAO, AIProviderDAOError
+from app.daos.ai_settings_dao import AISettingsDAO, AISettingsDAOError
+from app.dtos.ai_settings_dto import (
+    AIProviderRuntimeDTO,
+    AIProviderRecordDTO,
+    AISettingsRecordDTO,
+    ResolvedAIConfigurationDTO,
+)
+
+
+class AIConfigurationServiceError(RuntimeError):
+    """Raised when the AI configuration cannot be resolved."""
+
+
+class AIConfigurationService:
+    """Expose helpers to retrieve providers and resolve runtime settings."""
+
+    LOCAL_KEY = "local"
+    OPENAI_KEYS = {"openai_mini", "openai_turbo"}
+    MISTRAL_KEY = "mistral"
+
+    def __init__(
+        self,
+        settings_dao: AISettingsDAO,
+        provider_dao: AIProviderDAO,
+        configuration: Optional[AIConfiguration] = None,
+        secret_key: Optional[str] = None,
+    ) -> None:
+        """Persist dependencies required to resolve configuration data."""
+
+        self._settings_dao = settings_dao
+        self._provider_dao = provider_dao
+        self._configuration = configuration or AIConfiguration()
+        self._secret_key = secret_key or os.getenv("AI_SECRET_KEY", "")
+
+    def list_providers(self) -> List[AIProviderRuntimeDTO]:
+        """Return all configured providers with decrypted credentials."""
+
+        records = self._get_provider_records()
+        providers: List[AIProviderRuntimeDTO] = []
+        for record in records:
+            providers.append(self._record_to_runtime(record))
+        providers.sort(key=lambda item: (not item.favorite, item.displayName.lower()))
+        return providers
+
+    def get_default_provider_key(self) -> str:
+        """Return the provider key that should be preselected by default."""
+
+        providers = self.list_providers()
+        favorite = next((item for item in providers if item.favorite), None)
+        if favorite:
+            return favorite.providerKey
+
+        settings = self._get_settings()
+        fallback = next(
+            (item for item in providers if item.providerKey == settings.activeProvider),
+            None,
+        )
+        if fallback:
+            return fallback.providerKey
+
+        if providers:
+            return providers[0].providerKey
+
+        return self.LOCAL_KEY
+
+    def resolve_configuration(
+        self, selected_provider: Optional[str] = None
+    ) -> ResolvedAIConfigurationDTO:
+        """Combine provider data with global settings for runtime usage."""
+
+        providers = self.list_providers()
+        settings = self._get_settings()
+
+        provider = self._select_provider(providers, settings, selected_provider)
+        base_url = provider.baseUrl
+        if not base_url and provider.providerKey == self.LOCAL_KEY:
+            base_url = self._configuration.get_api_url()
+        if not base_url and provider.providerKey == self.MISTRAL_KEY:
+            base_url = "https://api.mistral.ai/v1"
+
+        temperature = settings.temperature or self._configuration.get_temperature()
+        max_tokens = settings.maxTokens or self._configuration.get_max_tokens()
+        timeout_seconds = settings.timeoutSeconds or 180
+        top_p = self._configuration.get_top_p()
+
+        return ResolvedAIConfigurationDTO(
+            providerKey=provider.providerKey,
+            displayName=provider.displayName,
+            baseUrl=base_url,
+            apiKey=provider.apiKey,
+            orgId=provider.orgId,
+            modelName=provider.modelName or self._configuration.get_model_name(),
+            temperature=temperature,
+            topP=top_p,
+            maxTokens=max_tokens,
+            timeoutSeconds=timeout_seconds,
+            useRagLocal=settings.useRagLocal,
+            extra=provider.extra,
+        )
+
+    def _select_provider(
+        self,
+        providers: List[AIProviderRuntimeDTO],
+        settings: AISettingsRecordDTO,
+        selected_provider: Optional[str],
+    ) -> AIProviderRuntimeDTO:
+        """Choose the runtime provider considering the different fallbacks."""
+
+        provider_map: Dict[str, AIProviderRuntimeDTO] = {
+            provider.providerKey: provider for provider in providers
+        }
+
+        if selected_provider and selected_provider in provider_map:
+            return provider_map[selected_provider]
+
+        favorite = next((item for item in providers if item.favorite), None)
+        if favorite:
+            return favorite
+
+        if settings.activeProvider in provider_map:
+            return provider_map[settings.activeProvider]
+
+        if providers:
+            return providers[0]
+
+        return AIProviderRuntimeDTO(
+            providerKey=self.LOCAL_KEY,
+            displayName="Local",
+            baseUrl=self._configuration.get_api_url(),
+            apiKey=self._configuration.get_api_key(),
+            orgId=None,
+            modelName=self._configuration.get_model_name(),
+            extra={},
+            favorite=True,
+        )
+
+    def _get_provider_records(self) -> List[AIProviderRecordDTO]:
+        """Retrieve provider rows from the DAO and wrap errors consistently."""
+
+        try:
+            return self._provider_dao.list_providers()
+        except AIProviderDAOError as exc:  # pragma: no cover - dependencias externas
+            raise AIConfigurationServiceError(str(exc)) from exc
+
+    def _get_settings(self) -> AISettingsRecordDTO:
+        """Retrieve global AI settings handling DAO errors uniformly."""
+
+        try:
+            return self._settings_dao.get_settings()
+        except AISettingsDAOError as exc:  # pragma: no cover - dependencias externas
+            raise AIConfigurationServiceError(str(exc)) from exc
+
+    def _record_to_runtime(self, record: AIProviderRecordDTO) -> AIProviderRuntimeDTO:
+        """Decrypt a provider record and normalize display metadata."""
+
+        decrypted_key = self._decrypt_api_key(record.apiKeyEncrypted)
+        display_name = str(record.extra.get("label") or record.providerKey)
+        base_url = record.baseUrl
+        if not base_url and record.providerKey == self.LOCAL_KEY:
+            base_url = self._configuration.get_api_url()
+        if not base_url and record.providerKey == self.MISTRAL_KEY:
+            base_url = "https://api.mistral.ai/v1"
+
+        return AIProviderRuntimeDTO(
+            providerKey=record.providerKey,
+            displayName=display_name,
+            baseUrl=base_url,
+            apiKey=decrypted_key,
+            orgId=record.orgId,
+            modelName=record.modelName or self._configuration.get_model_name(),
+            extra=record.extra,
+            favorite=record.favorite,
+        )
+
+    def _decrypt_api_key(self, encrypted: Optional[str]) -> Optional[str]:
+        """Attempt to decode the stored API key using a best-effort strategy."""
+
+        if not encrypted:
+            return None
+
+        token = encrypted.strip()
+        if not token:
+            return None
+
+        try:
+            decoded = base64.b64decode(token).decode("utf-8")
+        except Exception:  # pragma: no cover - depende del formato almacenado
+            decoded = token
+
+        if not self._secret_key:
+            return decoded
+
+        secret_bytes = self._secret_key.encode("utf-8")
+        decoded_bytes = decoded.encode("utf-8")
+        xored = bytes(
+            byte ^ secret_bytes[index % len(secret_bytes)]
+            for index, byte in enumerate(decoded_bytes)
+        )
+        try:
+            return xored.decode("utf-8")
+        except UnicodeDecodeError:  # pragma: no cover - depende de la clave guardada
+            return decoded

--- a/app/services/card_ai_service.py
+++ b/app/services/card_ai_service.py
@@ -25,10 +25,16 @@ except ModuleNotFoundError:  # pragma: no cover
         post=_missing_post,
     )
 
+try:  # pragma: no cover - la librería openai es opcional
+    from openai import OpenAI  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - depende del entorno
+    OpenAI = None  # type: ignore[assignment]
+
 from app.config.ai_config import AIConfiguration
 from app.daos.card_ai_input_dao import CardAIInputDAO, CardAIInputDAOError
 from app.daos.card_ai_output_dao import CardAIOutputDAO, CardAIOutputDAOError
 from app.daos.card_dao import CardDAO, CardDAOError
+from app.dtos.ai_settings_dto import AIProviderRuntimeDTO, ResolvedAIConfigurationDTO
 from app.dtos.card_ai_dto import (
     CardAIHistoryEntryDTO,
     CardAIInputDTO,
@@ -37,6 +43,10 @@ from app.dtos.card_ai_dto import (
     CardAIOutputDTO,
     CardDTO,
     CardFiltersDTO,
+)
+from app.services.ai_configuration_service import (
+    AIConfigurationService,
+    AIConfigurationServiceError,
 )
 
 if TYPE_CHECKING:  # pragma: no cover - solo para anotaciones
@@ -58,12 +68,19 @@ class CardAIService:
         card_dao: CardDAO,
         input_dao: CardAIInputDAO,
         output_dao: CardAIOutputDAO,
+        configuration_service: AIConfigurationService,
         configuration: Optional[AIConfiguration] = None,
         http_post: Optional[Callable[..., requests.Response]] = None,
         system_prompt_loader: Optional[Callable[[], str]] = None,
         context_service: Optional["RAGContextService"] = None,
+        openai_client_factory: Optional[
+            Callable[[str, Optional[str], Optional[str], int], object]
+        ] = None,
     ) -> None:
         """Store dependencies used by the service."""
+
+        if configuration_service is None:
+            raise ValueError("configuration_service es requerido")
 
         self._card_dao = card_dao
         self._input_dao = input_dao
@@ -74,6 +91,10 @@ class CardAIService:
             system_prompt_loader or self._load_system_prompt_from_file
         )
         self._context_service = context_service
+        self._configuration_service = configuration_service
+        self._openai_client_factory: Callable[
+            [str, Optional[str], Optional[str], int], object
+        ] = openai_client_factory or self._default_openai_client_factory
 
     @staticmethod
     def calculate_completeness(payload: CardAIRequestDTO) -> int:
@@ -95,6 +116,22 @@ class CardAIService:
         try:
             return self._card_dao.list_cards(filters, limit=limit)
         except CardDAOError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+    def list_providers(self) -> List[AIProviderRuntimeDTO]:
+        """Expose the configured AI providers to the presentation layer."""
+
+        try:
+            return self._configuration_service.list_providers()
+        except AIConfigurationServiceError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+    def get_default_provider_key(self) -> str:
+        """Return the provider key that should be selected by default."""
+
+        try:
+            return self._configuration_service.get_default_provider_key()
+        except AIConfigurationServiceError as exc:
             raise CardAIServiceError(str(exc)) from exc
 
     def list_inputs(self, card_id: int, limit: int = 50) -> List[CardAIInputDTO]:
@@ -231,24 +268,10 @@ class CardAIService:
             "Integra la información anterior únicamente como referencia técnica; evita copiarla textualmente y prioriza la coherencia con el nuevo caso."
         )
 
-    def _call_llm(self, prompt: str, context: str = "") -> Dict[str, object]:
-        """Send the completion request to the configured LLM."""
-
-        headers = {"Content-Type": "application/json"}
-        token = self._config.get_api_key()
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        else:
-            headers["Authorization"] = "Bearer local"
-
-        try:
-            system_prompt = self._system_prompt_loader()
-        except CardAIServiceError:
-            raise
-        except Exception as exc:  # pragma: no cover - fallback ante errores inesperados
-            raise CardAIServiceError(
-                "No fue posible cargar el prompt de sistema solicitado."
-            ) from exc
+    def _build_messages(
+        self, system_prompt: str, user_prompt: str, context: str
+    ) -> List[Dict[str, str]]:
+        """Compose the chat messages sent to any provider."""
 
         messages: List[Dict[str, str]] = [
             {"role": "system", "content": system_prompt},
@@ -260,35 +283,22 @@ class CardAIService:
                     "content": self._build_context_message(context),
                 }
             )
-        messages.append({"role": "user", "content": prompt})
+        messages.append({"role": "user", "content": user_prompt})
+        return messages
 
-        payload = {
-            "model": self._config.get_model_name(),
-            "messages": messages,
-            "temperature": self._config.get_temperature(),
-            "top_p": self._config.get_top_p(),
-            "max_tokens": self._config.get_max_tokens(),
-        }
+    def _call_llm(
+        self, messages: List[Dict[str, str]], configuration: ResolvedAIConfigurationDTO
+    ) -> Dict[str, object]:
+        """Invoke the configured provider using the resolved configuration."""
 
-        try:
-            response = self._http_post(
-                self._config.get_api_url(),
-                headers=headers,
-                json=payload,
-                timeout=180000,
-            )
-        except requests.RequestException as exc:
-            raise CardAIServiceError(f"No fue posible contactar al modelo: {exc}") from exc
-
-        if not response.ok:
-            raise CardAIServiceError(
-                f"Error del modelo {response.status_code}: {response.text.strip()[:200]}"
-            )
-
-        try:
-            return response.json()
-        except ValueError as exc:
-            raise CardAIServiceError("La respuesta del modelo no es JSON válido.") from exc
+        provider_key = configuration.providerKey
+        if provider_key == AIConfigurationService.LOCAL_KEY:
+            return self._invoke_local(messages, configuration)
+        if provider_key in AIConfigurationService.OPENAI_KEYS:
+            return self._invoke_openai(messages, configuration)
+        if provider_key == AIConfigurationService.MISTRAL_KEY:
+            return self._invoke_mistral(messages, configuration)
+        raise CardAIServiceError(f"Proveedor de IA desconocido: {provider_key}")
 
     def generate_document(self, payload: CardAIRequestDTO) -> CardAIGenerationResultDTO:
         """Persist the prompt, invoke the LLM and store the resulting JSON."""
@@ -297,6 +307,22 @@ class CardAIService:
             titulo = self._card_dao.get_card_title(payload.cardId)
         except CardDAOError as exc:
             raise CardAIServiceError(str(exc)) from exc
+
+        try:
+            resolved_configuration = self._configuration_service.resolve_configuration(
+                payload.providerKey
+            )
+        except AIConfigurationServiceError as exc:
+            raise CardAIServiceError(str(exc)) from exc
+
+        try:
+            system_prompt = self._system_prompt_loader()
+        except CardAIServiceError:
+            raise
+        except Exception as exc:  # pragma: no cover - depende del sistema de archivos
+            raise CardAIServiceError(
+                "No fue posible cargar el prompt de sistema solicitado."
+            ) from exc
 
         completeness = self.calculate_completeness(payload)
         try:
@@ -317,7 +343,12 @@ class CardAIService:
         prompt = self._build_user_prompt(payload.tipo, titulo, payload)
         context_text = ""
         context_titles: List[str] = []
-        if self._context_service:
+        use_rag = (
+            resolved_configuration.providerKey == AIConfigurationService.LOCAL_KEY
+            and resolved_configuration.useRagLocal
+            and self._context_service is not None
+        )
+        if use_rag:
             query_parts = [
                 titulo,
                 payload.descripcion or "",
@@ -331,7 +362,8 @@ class CardAIService:
                     context_text, context_titles = self._context_service.search_context(query)
                 except Exception as exc:  # pragma: no cover - depende de librerías opcionales
                     logger.warning("No fue posible recuperar contexto previo: %s", exc)
-        llm_response = self._call_llm(prompt, context_text)
+        messages = self._build_messages(system_prompt, prompt, context_text)
+        llm_response = self._call_llm(messages, resolved_configuration)
 
         try:
             content = llm_response["choices"][0]["message"]["content"]
@@ -351,7 +383,7 @@ class CardAIService:
                 payload.cardId,
                 input_dto.inputId,
                 llm_response.get("id"),
-                llm_response.get("model"),
+                llm_response.get("model") or resolved_configuration.modelName,
                 llm_response.get("usage"),
                 content_json,
             )
@@ -359,6 +391,163 @@ class CardAIService:
             raise CardAIServiceError(str(exc)) from exc
 
         return CardAIGenerationResultDTO(input=input_dto, output=output_dto, completenessPct=completeness)
+
+    def _invoke_local(
+        self, messages: List[Dict[str, str]], configuration: ResolvedAIConfigurationDTO
+    ) -> Dict[str, object]:
+        """Send the request to a local OpenAI-compatible endpoint."""
+
+        base_url = configuration.baseUrl or self._config.get_api_url()
+        if not base_url:
+            raise CardAIServiceError(
+                "No se encontró la URL base para el proveedor local configurado."
+            )
+        endpoint = f"{base_url.rstrip('/')}/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        if configuration.apiKey:
+            headers["Authorization"] = f"Bearer {configuration.apiKey}"
+
+        payload = {
+            "model": configuration.modelName,
+            "messages": messages,
+            "temperature": configuration.temperature,
+            "top_p": configuration.topP,
+            "max_tokens": configuration.maxTokens,
+            "stream": False,
+        }
+
+        try:
+            response = self._http_post(
+                endpoint,
+                headers=headers,
+                json=payload,
+                timeout=max(configuration.timeoutSeconds, 1),
+            )
+        except requests.RequestException as exc:
+            raise CardAIServiceError(f"No fue posible contactar al modelo: {exc}") from exc
+
+        if not response.ok:
+            raise CardAIServiceError(
+                f"Error del modelo {response.status_code}: {response.text.strip()[:200]}"
+            )
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise CardAIServiceError("La respuesta del modelo no es JSON válido.") from exc
+
+    def _invoke_mistral(
+        self, messages: List[Dict[str, str]], configuration: ResolvedAIConfigurationDTO
+    ) -> Dict[str, object]:
+        """Send the request to the Mistral HTTP API."""
+
+        if not configuration.apiKey:
+            raise CardAIServiceError("No se encontró la API key para el proveedor Mistral.")
+        base_url = configuration.baseUrl or "https://api.mistral.ai/v1"
+        endpoint = f"{base_url.rstrip('/')}/chat/completions"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {configuration.apiKey}",
+        }
+        payload = {
+            "model": configuration.modelName,
+            "messages": messages,
+            "temperature": configuration.temperature,
+            "max_tokens": configuration.maxTokens,
+        }
+
+        try:
+            response = self._http_post(
+                endpoint,
+                headers=headers,
+                json=payload,
+                timeout=max(configuration.timeoutSeconds, 1),
+            )
+        except requests.RequestException as exc:
+            raise CardAIServiceError(f"No fue posible contactar al modelo: {exc}") from exc
+
+        if not response.ok:
+            raise CardAIServiceError(
+                f"Error del modelo {response.status_code}: {response.text.strip()[:200]}"
+            )
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise CardAIServiceError("La respuesta del modelo no es JSON válido.") from exc
+
+    def _invoke_openai(
+        self, messages: List[Dict[str, str]], configuration: ResolvedAIConfigurationDTO
+    ) -> Dict[str, object]:
+        """Send the request using the official OpenAI SDK."""
+
+        if OpenAI is None and self._openai_client_factory is self._default_openai_client_factory:  # pragma: no cover - depende del entorno
+            raise CardAIServiceError(
+                "La librería 'openai' no está instalada en el entorno actual."
+            )
+        if not configuration.apiKey:
+            raise CardAIServiceError("No se encontró la API key para el proveedor OpenAI.")
+
+        client = self._openai_client_factory(
+            configuration.apiKey,
+            configuration.baseUrl,
+            configuration.orgId,
+            max(configuration.timeoutSeconds, 1),
+        )
+
+        try:
+            response = client.chat.completions.create(  # type: ignore[attr-defined]
+                model=configuration.modelName,
+                messages=messages,
+                temperature=configuration.temperature,
+                top_p=configuration.topP,
+                max_tokens=configuration.maxTokens,
+            )
+        except Exception as exc:  # pragma: no cover - depende del SDK remoto
+            raise CardAIServiceError(f"No fue posible contactar a OpenAI: {exc}") from exc
+
+        return self._normalize_openai_response(response)
+
+    def _normalize_openai_response(self, response: object) -> Dict[str, object]:
+        """Convert OpenAI SDK responses into plain dictionaries."""
+
+        if isinstance(response, dict):
+            return response
+
+        for attribute in ("model_dump", "to_dict", "dict"):
+            candidate = getattr(response, attribute, None)
+            if candidate is None:
+                continue
+            try:
+                data = candidate()
+            except TypeError:
+                data = candidate(exclude_none=False)
+            if isinstance(data, dict):
+                return data
+
+        raise CardAIServiceError("La respuesta de OpenAI no se puede serializar como diccionario.")
+
+    def _default_openai_client_factory(
+        self,
+        api_key: str,
+        base_url: Optional[str],
+        org_id: Optional[str],
+        timeout_seconds: int,
+    ) -> object:
+        """Instantiate the OpenAI client handling optional parameters."""
+
+        if OpenAI is None:  # pragma: no cover - depende del entorno
+            raise CardAIServiceError(
+                "La librería 'openai' no está instalada en el entorno actual."
+            )
+
+        client = OpenAI(api_key=api_key, organization=org_id, base_url=base_url)
+        try:
+            if timeout_seconds and hasattr(client, "with_options"):
+                return client.with_options(timeout=timeout_seconds)
+        except Exception:  # pragma: no cover - depende del SDK
+            pass
+        return client
 
     def _normalize_json_content(self, raw_content: str) -> str:
         """Remove markdown code fences from the JSON block returned by the LLM.

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -473,4 +473,25 @@ CREATE TABLE dbo.ai_providers (
     updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
     favorite BIT NOT NULL DEFAULT 0
 );
+
+CREATE TABLE dbo.ai_request_logs (
+    log_id BIGINT IDENTITY(1,1) PRIMARY KEY,
+    card_id BIGINT NULL,
+    input_id BIGINT NULL,
+    provider_key VARCHAR(32) NOT NULL,
+    model_name NVARCHAR(255) NULL,
+    request_payload NVARCHAR(MAX) NOT NULL,
+    response_payload NVARCHAR(MAX) NULL,
+    response_content NVARCHAR(MAX) NULL,
+    is_valid_json BIT NOT NULL DEFAULT 0,
+    error_message NVARCHAR(1024) NULL,
+    created_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT fk_ai_request_logs_card FOREIGN KEY (card_id)
+        REFERENCES dbo.cards(id) ON DELETE SET NULL,
+    CONSTRAINT fk_ai_request_logs_input FOREIGN KEY (input_id)
+        REFERENCES dbo.cards_ai_inputs(input_id) ON DELETE SET NULL
+);
+
+CREATE INDEX ix_ai_request_logs_created_at
+    ON dbo.ai_request_logs (created_at DESC, log_id DESC);
 ```

--- a/docs/database_schema.md
+++ b/docs/database_schema.md
@@ -451,4 +451,26 @@ CREATE TABLE dbo.cards_ai_outputs (
 );
 
 CREATE INDEX ix_cards_ai_outputs_card_id ON dbo.cards_ai_outputs (card_id DESC, output_id DESC);
+
+CREATE TABLE dbo.ai_settings (
+    id INT IDENTITY(1,1) PRIMARY KEY,
+    active_provider VARCHAR(32) NOT NULL DEFAULT 'local',
+    temperature FLOAT NOT NULL DEFAULT 0.35,
+    max_tokens INT NOT NULL DEFAULT 10000,
+    timeout_seconds INT NOT NULL DEFAULT 180,
+    use_rag_local BIT NOT NULL DEFAULT 1,
+    updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME()
+);
+
+CREATE TABLE dbo.ai_providers (
+    id INT IDENTITY(1,1) PRIMARY KEY,
+    provider_key VARCHAR(32) NOT NULL UNIQUE,
+    base_url NVARCHAR(2048) NULL,
+    api_key_enc NVARCHAR(MAX) NULL,
+    org_id NVARCHAR(255) NULL,
+    model_name NVARCHAR(255) NULL,
+    extra_json NVARCHAR(MAX) NULL,
+    updated_at DATETIME2(0) NOT NULL DEFAULT SYSUTCDATETIME(),
+    favorite BIT NOT NULL DEFAULT 0
+);
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ MouseInfo==0.1.3
 mss==10.1.0
 numpy==2.3.2
 openpyxl==3.1.5
+openai==1.61.0
 packaging==25.0
 pandas==2.3.2
 pillow==10.4.0

--- a/tests/test_card_ai_service.py
+++ b/tests/test_card_ai_service.py
@@ -10,6 +10,7 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from app.config.ai_config import AIConfiguration
+from app.daos.ai_request_log_dao import AIRequestLogDAOError
 from app.daos.card_ai_output_dao import CardAIOutputDAOError
 from app.dtos.ai_settings_dto import AIProviderRuntimeDTO, ResolvedAIConfigurationDTO
 from app.dtos.card_ai_dto import CardAIRequestDTO, CardDTO, CardFiltersDTO
@@ -174,6 +175,54 @@ class FakeOutputDAO:
         return dto
 
 
+class FakeRequestLogDAO:
+    """Capture request/response audit entries for assertions."""
+
+    def __init__(self) -> None:
+        self.created: List[Dict[str, object]] = []
+        self.fail = False
+
+    def create_log(
+        self,
+        card_id: Optional[int],
+        input_id: Optional[int],
+        provider_key: str,
+        model_name: Optional[str],
+        request_payload: str,
+        response_payload: Optional[str],
+        response_content: Optional[str],
+        is_valid_json: bool,
+        error_message: Optional[str],
+    ):
+        if self.fail:
+            raise AIRequestLogDAOError("boom")
+        entry = {
+            "card_id": card_id,
+            "input_id": input_id,
+            "provider_key": provider_key,
+            "model_name": model_name,
+            "request_payload": request_payload,
+            "response_payload": response_payload,
+            "response_content": response_content,
+            "is_valid_json": is_valid_json,
+            "error_message": error_message,
+        }
+        self.created.append(entry)
+        dto = type("LogDTO", (), {})()
+        dto.logId = len(self.created)
+        dto.cardId = card_id
+        dto.inputId = input_id
+        dto.providerKey = provider_key
+        dto.modelName = model_name
+        dto.requestPayload = request_payload
+        dto.responsePayload = response_payload
+        dto.responseContent = response_content
+        dto.isValidJson = is_valid_json
+        dto.errorMessage = error_message
+        dto.createdAt = datetime.now(timezone.utc)
+        return dto
+
+
 class FakeContextService:
     """Provide deterministic context snippets for the prompt builder tests."""
 
@@ -312,6 +361,7 @@ def test_calculate_completeness_counts_non_empty_fields() -> None:
         FakeCardDAO(),
         FakeInputDAO(),
         FakeOutputDAO(),
+        FakeRequestLogDAO(),
         FakeAIConfigurationService(),
         http_post=successful_http_post,
     )
@@ -335,6 +385,7 @@ def test_delete_output_delegates_to_dao() -> None:
         FakeCardDAO(),
         FakeInputDAO(),
         fake_output,
+        FakeRequestLogDAO(),
         FakeAIConfigurationService(),
         http_post=successful_http_post,
     )
@@ -353,6 +404,7 @@ def test_delete_output_wraps_dao_errors() -> None:
         FakeCardDAO(),
         FakeInputDAO(),
         fake_output,
+        FakeRequestLogDAO(),
         FakeAIConfigurationService(),
         http_post=successful_http_post,
     )
@@ -369,6 +421,7 @@ def test_save_draft_persists_input_and_marks_as_draft() -> None:
         FakeCardDAO(),
         fake_input,
         FakeOutputDAO(),
+        FakeRequestLogDAO(),
         FakeAIConfigurationService(),
         http_post=successful_http_post,
     )
@@ -391,10 +444,12 @@ def test_generate_document_calls_llm_and_stores_output() -> None:
 
     fake_input = FakeInputDAO()
     fake_output = FakeOutputDAO()
+    fake_logs = FakeRequestLogDAO()
     service = CardAIService(
         FakeCardDAO(),
         fake_input,
         fake_output,
+        fake_logs,
         FakeAIConfigurationService(),
         http_post=successful_http_post,
     )
@@ -412,6 +467,9 @@ def test_generate_document_calls_llm_and_stores_output() -> None:
     assert result.output.outputId == fake_output.created[0].outputId
     assert result.output.content["titulo"] == "Demo"
     assert result.output.ddeGenerated is False
+    assert len(fake_logs.created) == 1
+    assert fake_logs.created[0]["is_valid_json"] is True
+    assert json.loads(fake_logs.created[0]["response_payload"])["id"] == "chatcmpl-1"
 
 
 def test_generate_document_parses_markdown_fenced_json() -> None:
@@ -419,10 +477,12 @@ def test_generate_document_parses_markdown_fenced_json() -> None:
 
     fake_input = FakeInputDAO()
     fake_output = FakeOutputDAO()
+    fake_logs = FakeRequestLogDAO()
     service = CardAIService(
         FakeCardDAO(),
         fake_input,
         fake_output,
+        fake_logs,
         FakeAIConfigurationService(),
         http_post=codeblock_http_post,
     )
@@ -437,15 +497,18 @@ def test_generate_document_parses_markdown_fenced_json() -> None:
     )
     result = service.generate_document(payload)
     assert result.output.content["titulo"] == "Demo cercado"
+    assert fake_logs.created[0]["response_content"].startswith("{")
 
 
 def test_generate_document_handles_llm_errors() -> None:
     """Non-200 responses from the LLM should raise a service error."""
 
+    fake_logs = FakeRequestLogDAO()
     service = CardAIService(
         FakeCardDAO(),
         FakeInputDAO(),
         FakeOutputDAO(),
+        fake_logs,
         FakeAIConfigurationService(),
         http_post=failing_http_post,
     )
@@ -461,6 +524,40 @@ def test_generate_document_handles_llm_errors() -> None:
     with pytest.raises(CardAIServiceError):
         service.generate_document(payload)
 
+    assert fake_logs.created[0]["is_valid_json"] is False
+    assert "Error del modelo" in fake_logs.created[0]["error_message"]
+
+
+def test_generate_document_continues_when_log_persist_fails() -> None:
+    """Failures while storing the audit entry should not block the workflow."""
+
+    fake_input = FakeInputDAO()
+    fake_output = FakeOutputDAO()
+    fake_logs = FakeRequestLogDAO()
+    fake_logs.fail = True
+    service = CardAIService(
+        FakeCardDAO(),
+        fake_input,
+        fake_output,
+        fake_logs,
+        FakeAIConfigurationService(),
+        http_post=successful_http_post,
+    )
+    payload = CardAIRequestDTO(
+        cardId=1,
+        tipo="INCIDENCIA",
+        descripcion="Descripción",
+        analisis="",
+        recomendaciones="",
+        cosasPrevenir="",
+        infoAdicional="",
+    )
+
+    result = service.generate_document(payload)
+
+    assert result.output.content["titulo"] == "Demo"
+    assert fake_output.created
+
 
 def test_generate_document_sends_system_prompt_first() -> None:
     """The LLM request must prepend the corporate system prompt before user content."""
@@ -471,10 +568,12 @@ def test_generate_document_sends_system_prompt_first() -> None:
         captured["payload"] = kwargs.get("json")
         return successful_http_post()
 
+    fake_logs = FakeRequestLogDAO()
     service = CardAIService(
         FakeCardDAO(),
         FakeInputDAO(),
         FakeOutputDAO(),
+        fake_logs,
         FakeAIConfigurationService(),
         http_post=capturing_http_post,
     )
@@ -497,6 +596,8 @@ def test_generate_document_sends_system_prompt_first() -> None:
     assert messages[0]["content"] == DEFAULT_SYSTEM_PROMPT
     assert messages[1]["role"] == "user"
     assert "Genera un documento formal" in messages[1]["content"]
+    request_logged = json.loads(fake_logs.created[0]["request_payload"])
+    assert request_logged["messages"][0]["content"] == DEFAULT_SYSTEM_PROMPT
 
 
 def test_generate_document_injects_retrieved_context() -> None:
@@ -511,10 +612,12 @@ def test_generate_document_injects_retrieved_context() -> None:
     fake_input = FakeInputDAO()
     fake_output = FakeOutputDAO()
     context_service = FakeContextService()
+    fake_logs = FakeRequestLogDAO()
     service = CardAIService(
         FakeCardDAO(),
         fake_input,
         fake_output,
+        fake_logs,
         FakeAIConfigurationService(),
         http_post=capturing_http_post,
         context_service=context_service,
@@ -542,6 +645,8 @@ def test_generate_document_injects_retrieved_context() -> None:
     assert messages[2]["role"] == "user"
     assert context_service.receivedQueries[0].startswith("EA-172")
     assert result.output.content["usados_como_contexto"] == context_service.contextTitles
+    log_entry = json.loads(fake_logs.created[0]["request_payload"])
+    assert log_entry["contextTitles"] == context_service.contextTitles
 
 
 def test_generate_document_uses_openai_factory_when_provider_remote() -> None:
@@ -586,11 +691,13 @@ def test_generate_document_uses_openai_factory_when_provider_remote() -> None:
     )
     fake_input = FakeInputDAO()
     fake_output = FakeOutputDAO()
+    fake_logs = FakeRequestLogDAO()
     context_service = FakeContextService()
     service = CardAIService(
         FakeCardDAO(),
         fake_input,
         fake_output,
+        fake_logs,
         config_service,
         context_service=context_service,
         openai_client_factory=fake_factory,
@@ -613,6 +720,7 @@ def test_generate_document_uses_openai_factory_when_provider_remote() -> None:
     assert "messages" in captured["openai_payload"]
     assert context_service.receivedQueries == []
     assert "usados_como_contexto" not in result.output.content
+    assert json.loads(fake_logs.created[0]["request_payload"])["providerKey"] == "openai_mini"
 
 
 def test_generate_document_uses_custom_system_prompt_file(tmp_path) -> None:
@@ -632,6 +740,7 @@ def test_generate_document_uses_custom_system_prompt_file(tmp_path) -> None:
         FakeCardDAO(),
         FakeInputDAO(),
         FakeOutputDAO(),
+        FakeRequestLogDAO(),
         FakeAIConfigurationService(),
         configuration=config,
         http_post=capturing_http_post,
@@ -664,6 +773,7 @@ def test_generate_document_fails_when_system_prompt_missing(tmp_path) -> None:
         FakeCardDAO(),
         FakeInputDAO(),
         FakeOutputDAO(),
+        FakeRequestLogDAO(),
         FakeAIConfigurationService(),
         configuration=config,
         http_post=successful_http_post,
@@ -691,10 +801,12 @@ def test_mark_output_as_best_reindexes_context() -> None:
     fake_input = FakeInputDAO()
     fake_output = FakeOutputDAO()
     context_service = FakeContextService()
+    fake_logs = FakeRequestLogDAO()
     service = CardAIService(
         FakeCardDAO(),
         fake_input,
         fake_output,
+        fake_logs,
         FakeAIConfigurationService(),
         http_post=successful_http_post,
         context_service=context_service,
@@ -727,6 +839,7 @@ def test_mark_output_as_best_wraps_dao_errors() -> None:
         FakeCardDAO(),
         FakeInputDAO(),
         fake_output,
+        FakeRequestLogDAO(),
         FakeAIConfigurationService(),
         http_post=successful_http_post,
     )
@@ -740,10 +853,12 @@ def test_set_output_dde_generated_updates_flag() -> None:
 
     fake_input = FakeInputDAO()
     fake_output = FakeOutputDAO()
+    fake_logs = FakeRequestLogDAO()
     service = CardAIService(
         FakeCardDAO(),
         fake_input,
         fake_output,
+        fake_logs,
         FakeAIConfigurationService(),
         http_post=successful_http_post,
     )
@@ -777,6 +892,7 @@ def test_set_output_dde_generated_wraps_dao_errors() -> None:
         FakeCardDAO(),
         FakeInputDAO(),
         fake_output,
+        FakeRequestLogDAO(),
         FakeAIConfigurationService(),
         http_post=successful_http_post,
     )


### PR DESCRIPTION
## Summary
- add AI settings and provider DAOs plus a configuration service to resolve provider metadata from SQL Server
- extend CardAIService to support local, OpenAI, and Mistral providers while wiring the new configuration into MainController
- expose an AI provider selector in the capture form, document the new tables, add the OpenAI dependency, and update tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_69091d8501b0832ca9206d0a8a14147e